### PR TITLE
Add automatic Klipper restart after installing extras modules

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -232,4 +232,12 @@ else
 fi
 echo "Probe Pressure ...[Done]"
 
+echo "Restarting Klipper service to load new modules..."
+sudo systemctl restart klipper
+if [ $? -eq 0 ]; then
+    echo "✅ Klipper restarted successfully!"
+else
+    echo "⚠️ Warning: Failed to restart Klipper. Please restart manually with: sudo systemctl restart klipper"
+fi
+
 echo "Installation terminée."


### PR DESCRIPTION
After copying Python modules to klipper/klippy/extras/, the script now automatically restarts the Klipper service to load the new modules. This ensures that filament_yumi_smart_motion_sensor.py, yumi_z_offset_calculator.py, and probe_pressure.py are immediately available without requiring manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)