### PR TITLE
Add factory QC system for KlipperScreen

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -254,6 +254,73 @@ else
     echo "ℹ️ Script called by Moonraker - Klipper will be restarted automatically by Moonraker"
 fi
 
+# === QC System (Quality Control) ===
+echo "Installing QC System..."
+QC_DIR="$PROJECT_DIR/qc"
+if [ -d "$QC_DIR" ]; then
+    # QC Macros for Klipper
+    cp "$QC_DIR/qc_macros.cfg" "$KLIPPER_CONFIG_DIR/qc_macros.cfg" && echo "qc_macros.cfg copied successfully." || echo "Error copying qc_macros.cfg."
+
+    # Add include in printer.cfg if not present
+    if [ -f "$KLIPPER_CONFIG_DIR/printer.cfg" ]; then
+        if ! grep -q "qc_macros.cfg" "$KLIPPER_CONFIG_DIR/printer.cfg"; then
+            sed -i '/include mainsail.cfg/a [include qc_macros.cfg]' "$KLIPPER_CONFIG_DIR/printer.cfg"
+            echo "Added [include qc_macros.cfg] to printer.cfg"
+        else
+            echo "[include qc_macros.cfg] already in printer.cfg"
+        fi
+    fi
+
+    # KlipperScreen panel (symlinks)
+    if [ -d "$USER_HOME/KlipperScreen/panels" ]; then
+        # QC wizard panel
+        if [ -L "$USER_HOME/KlipperScreen/panels/qc_wizard.py" ]; then
+            rm "$USER_HOME/KlipperScreen/panels/qc_wizard.py"
+        fi
+        ln -sf "$QC_DIR/qc_wizard.py" "$USER_HOME/KlipperScreen/panels/qc_wizard.py"
+        echo "Symlink created: panels/qc_wizard.py"
+
+        # QC engine module
+        if [ -L "$USER_HOME/KlipperScreen/ks_includes/qc_engine.py" ]; then
+            rm "$USER_HOME/KlipperScreen/ks_includes/qc_engine.py"
+        fi
+        ln -sf "$QC_DIR/qc_engine.py" "$USER_HOME/KlipperScreen/ks_includes/qc_engine.py"
+        echo "Symlink created: ks_includes/qc_engine.py"
+
+        # QC icon
+        for style_dir in material-dark material-darker; do
+            if [ -d "$USER_HOME/KlipperScreen/styles/$style_dir/images" ]; then
+                cp "$QC_DIR/qc-check.svg" "$USER_HOME/KlipperScreen/styles/$style_dir/images/qc-check.svg"
+                echo "QC icon copied to $style_dir"
+            fi
+        done
+    fi
+
+    # KlipperScreen menu entry
+    if [ -f "$CONFIG_FILE" ]; then
+        if ! grep -q "qc_wizard" "$CONFIG_FILE"; then
+            cat >> "$CONFIG_FILE" <<'QCMENU'
+
+[menu __main more qc]
+name: Quality Control
+icon: qc-check
+panel: qc_wizard
+QCMENU
+            echo "Added QC menu entry to KlipperScreen.conf"
+        else
+            echo "QC menu entry already in KlipperScreen.conf"
+        fi
+    fi
+
+    # QC reports directory
+    mkdir -p "$KLIPPER_CONFIG_DIR/qc_reports"
+    chown -R "$OWNER:$OWNER" "$KLIPPER_CONFIG_DIR/qc_reports"
+    echo "QC reports directory ready."
+else
+    echo "QC directory not found, skipping QC installation."
+fi
+echo "QC System ...[Done]"
+
 echo "Configuring Mainsail settings..."
 # Replace Mainsail config.json with Yumi template
 MAINSAIL_DIR="$USER_HOME/mainsail"

--- a/qc/qc-check.svg
+++ b/qc/qc-check.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 11l3 3L22 4"/>
+  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+</svg>

--- a/qc/qc_engine.py
+++ b/qc/qc_engine.py
@@ -1,0 +1,360 @@
+"""
+QC Engine — State machine, test definitions, and report generator
+for Yumi Lab factory quality control protocol.
+"""
+import json
+import os
+import logging
+from datetime import datetime
+from enum import Enum
+
+logger = logging.getLogger("KlipperScreen.qc_engine")
+
+
+class QCState(Enum):
+    IDLE = "idle"
+    RUNNING = "running"
+    WAITING_GCODE = "waiting_gcode"
+    WAITING_VISUAL = "waiting_visual"
+    COMPLETED = "completed"
+    ABORTED = "aborted"
+
+
+class QCResult(Enum):
+    PENDING = "pending"
+    PASS = "pass"
+    FAIL = "fail"
+    SKIPPED = "skipped"
+
+
+# Ordered list of all QC tests
+QC_TESTS = [
+    {
+        "id": "home_x",
+        "name": "X Axis Homing",
+        "type": "automated",
+        "macro": "QC_HOME_X",
+        "timeout": 30,
+    },
+    {
+        "id": "home_y",
+        "name": "Y Axis Homing",
+        "type": "automated",
+        "macro": "QC_HOME_Y",
+        "timeout": 30,
+    },
+    {
+        "id": "home_z",
+        "name": "Z Axis Homing",
+        "type": "automated",
+        "macro": "QC_HOME_Z",
+        "timeout": 60,
+    },
+    {
+        "id": "motor_dir_x",
+        "name": "X Motor Direction",
+        "type": "visual",
+        "macro": "QC_MOTOR_DIR_X",
+        "prompt": "L'axe X s'est-il déplacé vers la DROITE ?",
+        "timeout": 30,
+    },
+    {
+        "id": "motor_dir_y",
+        "name": "Y Motor Direction",
+        "type": "visual",
+        "macro": "QC_MOTOR_DIR_Y",
+        "prompt": "L'axe Y s'est-il déplacé vers l'ARRIÈRE ?",
+        "timeout": 30,
+    },
+    {
+        "id": "motor_dir_z",
+        "name": "Z Motor Direction",
+        "type": "visual",
+        "macro": "QC_MOTOR_DIR_Z",
+        "prompt": "L'axe Z est-il monté vers le HAUT ?",
+        "timeout": 60,
+    },
+    {
+        "id": "travel_x",
+        "name": "X Full Travel",
+        "type": "visual",
+        "macro": "QC_TRAVEL_X",
+        "prompt": "L'axe X a-t-il parcouru toute sa course sans blocage ?",
+        "timeout": 60,
+    },
+    {
+        "id": "travel_y",
+        "name": "Y Full Travel",
+        "type": "visual",
+        "macro": "QC_TRAVEL_Y",
+        "prompt": "L'axe Y a-t-il parcouru toute sa course sans blocage ?",
+        "timeout": 60,
+    },
+    {
+        "id": "travel_z",
+        "name": "Z Full Travel",
+        "type": "visual",
+        "macro": "QC_TRAVEL_Z",
+        "prompt": "L'axe Z a-t-il parcouru toute sa course sans blocage ?",
+        "timeout": 120,
+    },
+    {
+        "id": "probe_check",
+        "name": "BLTouch Probe",
+        "type": "visual",
+        "macro": "QC_PROBE_CHECK",
+        "prompt": "Le BLTouch s'est-il déployé et rétracté correctement ?",
+        "timeout": 30,
+    },
+    {
+        "id": "fan_part",
+        "name": "Part Cooling Fan",
+        "type": "visual",
+        "macro": "QC_FAN_PART",
+        "prompt": "Le ventilateur de refroidissement pièce tourne-t-il ?",
+        "timeout": 15,
+    },
+    {
+        "id": "fan_hotend",
+        "name": "Hotend Fan",
+        "type": "visual",
+        "macro": "QC_FAN_HOTEND",
+        "prompt": "Le ventilateur du hotend tourne-t-il ?",
+        "timeout": 30,
+    },
+    {
+        "id": "heat_extruder",
+        "name": "Extruder Heating",
+        "type": "automated",
+        "macro": "QC_HEAT_EXTRUDER",
+        "timeout": 180,
+    },
+    {
+        "id": "heat_bed",
+        "name": "Bed Heating",
+        "type": "automated",
+        "macro": "QC_HEAT_BED",
+        "timeout": 300,
+    },
+    {
+        "id": "pid_extruder",
+        "name": "PID Extruder",
+        "type": "automated",
+        "macro": "QC_PID_EXTRUDER",
+        "timeout": 300,
+    },
+    {
+        "id": "pid_bed",
+        "name": "PID Bed",
+        "type": "automated",
+        "macro": "QC_PID_BED",
+        "timeout": 600,
+    },
+    {
+        "id": "bed_mesh",
+        "name": "Bed Mesh",
+        "type": "automated",
+        "macro": "QC_BED_MESH",
+        "timeout": 600,
+    },
+]
+
+
+class QCEngine:
+    def __init__(self):
+        self.state = QCState.IDLE
+        self.current_test_index = -1
+        self.results = {}
+        self.printer_id = ""
+        self.technician = ""
+        self.start_time = None
+        self.test_start_time = None
+        self._on_state_change = None
+        self._on_test_complete = None
+        self._on_visual_prompt = None
+        self._on_qc_complete = None
+
+    def set_callbacks(self, on_state_change=None, on_test_complete=None,
+                      on_visual_prompt=None, on_qc_complete=None):
+        self._on_state_change = on_state_change
+        self._on_test_complete = on_test_complete
+        self._on_visual_prompt = on_visual_prompt
+        self._on_qc_complete = on_qc_complete
+
+    def start(self, printer_id, technician=""):
+        self.printer_id = printer_id
+        self.technician = technician
+        self.start_time = datetime.now()
+        self.current_test_index = -1
+        self.results = {}
+        for test in QC_TESTS:
+            self.results[test["id"]] = {
+                "result": QCResult.PENDING,
+                "timestamp": None,
+                "details": "",
+            }
+        self._set_state(QCState.RUNNING)
+        return self.next_test()
+
+    def next_test(self):
+        """Advance to the next test. Returns the test dict or None if done."""
+        self.current_test_index += 1
+        if self.current_test_index >= len(QC_TESTS):
+            self._finish()
+            return None
+        test = QC_TESTS[self.current_test_index]
+        self.test_start_time = datetime.now()
+        logger.info(f"QC: Starting test {test['id']}")
+        return test
+
+    def get_current_test(self):
+        if 0 <= self.current_test_index < len(QC_TESTS):
+            return QC_TESTS[self.current_test_index]
+        return None
+
+    def get_progress(self):
+        """Returns (current, total) tuple."""
+        return (self.current_test_index + 1, len(QC_TESTS))
+
+    def process_gcode_response(self, message):
+        """Parse QC: prefixed gcode responses. Returns True if handled."""
+        if not message.startswith("QC:") and not message.startswith("echo: QC:"):
+            return False
+
+        # Strip echo prefix if present
+        msg = message.replace("echo: ", "").strip()
+        parts = msg.split(":")
+        if len(parts) < 3:
+            return False
+
+        test_id = parts[1]
+        status = parts[2]
+
+        test = self.get_current_test()
+        if not test or test["id"] != test_id:
+            logger.warning(f"QC: Received response for {test_id} but current test is {test['id'] if test else 'none'}")
+            return True
+
+        if status == "START":
+            self._set_state(QCState.WAITING_GCODE)
+            return True
+        elif status == "PASS":
+            self._record_result(test_id, QCResult.PASS)
+            return True
+        elif status == "FAIL":
+            self._record_result(test_id, QCResult.FAIL, "Automated check failed")
+            return True
+        elif status == "VISUAL":
+            self._set_state(QCState.WAITING_VISUAL)
+            if self._on_visual_prompt and "prompt" in test:
+                self._on_visual_prompt(test)
+            return True
+
+        return False
+
+    def record_visual_result(self, passed):
+        """Called by the UI when operator responds to a visual check."""
+        test = self.get_current_test()
+        if not test:
+            return
+        if passed:
+            self._record_result(test["id"], QCResult.PASS)
+        else:
+            self._record_result(test["id"], QCResult.FAIL, "Visual check: operator reported failure")
+
+    def skip_current_test(self):
+        """Skip the current test."""
+        test = self.get_current_test()
+        if test:
+            self._record_result(test["id"], QCResult.SKIPPED, "Skipped by operator")
+
+    def abort(self):
+        """Abort the entire QC process."""
+        self._set_state(QCState.ABORTED)
+        if self._on_qc_complete:
+            self._on_qc_complete(self.generate_report())
+
+    def _record_result(self, test_id, result, details=""):
+        self.results[test_id] = {
+            "result": result,
+            "timestamp": datetime.now().isoformat(),
+            "details": details,
+        }
+        logger.info(f"QC: Test {test_id} = {result.value}")
+
+        if self._on_test_complete:
+            self._on_test_complete(test_id, result)
+
+        # Auto-advance to next test
+        next_test = self.next_test()
+        if next_test is None:
+            return  # QC finished, _finish() already called
+
+    def _finish(self):
+        self._set_state(QCState.COMPLETED)
+        if self._on_qc_complete:
+            self._on_qc_complete(self.generate_report())
+
+    def _set_state(self, state):
+        old = self.state
+        self.state = state
+        if self._on_state_change:
+            self._on_state_change(old, state)
+
+    def generate_report(self):
+        end_time = datetime.now()
+        duration = (end_time - self.start_time).total_seconds() if self.start_time else 0
+
+        failed = [tid for tid, r in self.results.items() if r["result"] == QCResult.FAIL]
+        skipped = [tid for tid, r in self.results.items() if r["result"] == QCResult.SKIPPED]
+
+        if failed:
+            overall = "FAIL"
+        elif skipped:
+            overall = "PARTIAL"
+        else:
+            overall = "PASS"
+
+        report = {
+            "version": "1.0",
+            "printer_id": self.printer_id,
+            "technician": self.technician,
+            "date": self.start_time.isoformat() if self.start_time else "",
+            "date_end": end_time.isoformat(),
+            "duration_seconds": int(duration),
+            "tests": [],
+            "overall_result": overall,
+            "failed_tests": failed,
+            "skipped_tests": skipped,
+        }
+
+        for test in QC_TESTS:
+            r = self.results.get(test["id"], {})
+            report["tests"].append({
+                "id": test["id"],
+                "name": test["name"],
+                "type": test["type"],
+                "result": r.get("result", QCResult.PENDING).value if isinstance(r.get("result"), QCResult) else str(r.get("result", "pending")),
+                "timestamp": r.get("timestamp", ""),
+                "details": r.get("details", ""),
+            })
+
+        return report
+
+    def save_report(self, report=None):
+        """Save report as JSON file. Returns the file path."""
+        if report is None:
+            report = self.generate_report()
+
+        report_dir = os.path.expanduser("~/printer_data/config/qc_reports")
+        os.makedirs(report_dir, exist_ok=True)
+
+        date_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"QC_{self.printer_id}_{date_str}.json"
+        filepath = os.path.join(report_dir, filename)
+
+        with open(filepath, "w") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+
+        logger.info(f"QC: Report saved to {filepath}")
+        return filepath

--- a/qc/qc_macros.cfg
+++ b/qc/qc_macros.cfg
@@ -1,0 +1,236 @@
+#####################################################################
+# YUMI QC — Quality Control Macros
+# Each macro signals status via RESPOND MSG="QC:{test_id}:{STATUS}"
+# STATUS: START, PASS, FAIL, VISUAL (waiting for operator confirmation)
+#####################################################################
+
+# === HOMING TESTS ===
+
+[gcode_macro QC_HOME_X]
+description: QC - Home X axis
+gcode:
+    RESPOND MSG="QC:HOME_X:START"
+    G28 X
+    {% if "x" in printer.toolhead.homed_axes %}
+        RESPOND MSG="QC:HOME_X:PASS"
+    {% else %}
+        RESPOND MSG="QC:HOME_X:FAIL"
+    {% endif %}
+
+[gcode_macro QC_HOME_Y]
+description: QC - Home Y axis
+gcode:
+    RESPOND MSG="QC:HOME_Y:START"
+    G28 Y
+    {% if "y" in printer.toolhead.homed_axes %}
+        RESPOND MSG="QC:HOME_Y:PASS"
+    {% else %}
+        RESPOND MSG="QC:HOME_Y:FAIL"
+    {% endif %}
+
+[gcode_macro QC_HOME_Z]
+description: QC - Home Z axis (requires X and Y homed first)
+gcode:
+    RESPOND MSG="QC:HOME_Z:START"
+    {% if "xy" in printer.toolhead.homed_axes %}
+        G28 Z
+        {% if "z" in printer.toolhead.homed_axes %}
+            RESPOND MSG="QC:HOME_Z:PASS"
+        {% else %}
+            RESPOND MSG="QC:HOME_Z:FAIL"
+        {% endif %}
+    {% else %}
+        RESPOND MSG="QC:HOME_Z:FAIL"
+        {action_respond_info("QC: X and Y must be homed before Z")}
+    {% endif %}
+
+# === MOTOR DIRECTION TESTS ===
+
+[gcode_macro QC_MOTOR_DIR_X]
+description: QC - Move X +50mm for direction check
+gcode:
+    RESPOND MSG="QC:MOTOR_DIR_X:START"
+    G28 X
+    G90
+    G1 X50 F3000
+    RESPOND MSG="QC:MOTOR_DIR_X:VISUAL"
+
+[gcode_macro QC_MOTOR_DIR_Y]
+description: QC - Move Y +50mm for direction check
+gcode:
+    RESPOND MSG="QC:MOTOR_DIR_Y:START"
+    G28 Y
+    G90
+    G1 Y50 F3000
+    RESPOND MSG="QC:MOTOR_DIR_Y:VISUAL"
+
+[gcode_macro QC_MOTOR_DIR_Z]
+description: QC - Move Z +30mm for direction check
+gcode:
+    RESPOND MSG="QC:MOTOR_DIR_Z:START"
+    {% if "xy" in printer.toolhead.homed_axes %}
+        G28 Z
+        G90
+        G1 Z30 F600
+        RESPOND MSG="QC:MOTOR_DIR_Z:VISUAL"
+    {% else %}
+        G28
+        G90
+        G1 Z30 F600
+        RESPOND MSG="QC:MOTOR_DIR_Z:VISUAL"
+    {% endif %}
+
+# === FULL TRAVEL TESTS ===
+
+[gcode_macro QC_TRAVEL_X]
+description: QC - Move X to max position
+gcode:
+    RESPOND MSG="QC:TRAVEL_X:START"
+    G28 X
+    G90
+    {% set x_max = printer.toolhead.axis_maximum.x|float %}
+    G1 X{x_max - 5} F3000
+    G1 X5 F3000
+    RESPOND MSG="QC:TRAVEL_X:VISUAL"
+
+[gcode_macro QC_TRAVEL_Y]
+description: QC - Move Y to max position
+gcode:
+    RESPOND MSG="QC:TRAVEL_Y:START"
+    G28 Y
+    G90
+    {% set y_max = printer.toolhead.axis_maximum.y|float %}
+    G1 Y{y_max - 5} F3000
+    G1 Y5 F3000
+    RESPOND MSG="QC:TRAVEL_Y:VISUAL"
+
+[gcode_macro QC_TRAVEL_Z]
+description: QC - Move Z full travel
+gcode:
+    RESPOND MSG="QC:TRAVEL_Z:START"
+    {% if "xyz" not in printer.toolhead.homed_axes %}
+        G28
+    {% endif %}
+    G90
+    {% set z_max = printer.toolhead.axis_maximum.z|float %}
+    G1 Z{z_max - 10} F600
+    G1 Z5 F600
+    RESPOND MSG="QC:TRAVEL_Z:VISUAL"
+
+# === FAN TESTS ===
+
+[gcode_macro QC_FAN_PART]
+description: QC - Turn on part cooling fan
+gcode:
+    RESPOND MSG="QC:FAN_PART:START"
+    M106 S255
+    G4 P2000
+    RESPOND MSG="QC:FAN_PART:VISUAL"
+
+[gcode_macro QC_FAN_HOTEND]
+description: QC - Turn on hotend fan (heats to trigger temp)
+gcode:
+    RESPOND MSG="QC:FAN_HOTEND:START"
+    M104 S55
+    G4 P15000
+    RESPOND MSG="QC:FAN_HOTEND:VISUAL"
+
+[gcode_macro QC_FAN_STOP]
+description: QC - Stop all fans and heaters
+gcode:
+    M106 S0
+    M104 S0
+    M140 S0
+
+# === PROBE TEST ===
+
+[gcode_macro QC_PROBE_CHECK]
+description: QC - BLTouch deploy/retract test
+gcode:
+    RESPOND MSG="QC:PROBE_CHECK:START"
+    BLTOUCH_DEBUG COMMAND=pin_down
+    G4 P1000
+    BLTOUCH_DEBUG COMMAND=pin_up
+    G4 P1000
+    QUERY_PROBE
+    RESPOND MSG="QC:PROBE_CHECK:VISUAL"
+
+# === TEMPERATURE TESTS ===
+
+[gcode_macro QC_HEAT_EXTRUDER]
+description: QC - Heat extruder to 200C and verify
+gcode:
+    RESPOND MSG="QC:HEAT_EXTRUDER:START"
+    M104 S200
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM=195 MAXIMUM=210
+    RESPOND MSG="QC:HEAT_EXTRUDER:PASS"
+    M104 S0
+
+[gcode_macro QC_HEAT_BED]
+description: QC - Heat bed to 60C and verify
+gcode:
+    RESPOND MSG="QC:HEAT_BED:START"
+    M140 S60
+    TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM=56 MAXIMUM=70
+    RESPOND MSG="QC:HEAT_BED:PASS"
+    M140 S0
+
+# === PID CALIBRATION ===
+
+[gcode_macro QC_PID_EXTRUDER]
+description: QC - PID calibrate extruder
+gcode:
+    RESPOND MSG="QC:PID_EXTRUDER:START"
+    {% if "xyz" not in printer.toolhead.homed_axes %}
+        G28
+    {% endif %}
+    M106 S255
+    PID_CALIBRATE HEATER=extruder TARGET=190
+    M106 S0
+    RESPOND MSG="QC:PID_EXTRUDER:PASS"
+
+[gcode_macro QC_PID_BED]
+description: QC - PID calibrate bed
+gcode:
+    RESPOND MSG="QC:PID_BED:START"
+    {% if "xyz" not in printer.toolhead.homed_axes %}
+        G28
+    {% endif %}
+    M106 S255
+    PID_CALIBRATE HEATER=heater_bed TARGET=60
+    M106 S0
+    RESPOND MSG="QC:PID_BED:PASS"
+
+# === BED MESH ===
+
+[gcode_macro QC_BED_MESH]
+description: QC - Full bed mesh calibration
+gcode:
+    RESPOND MSG="QC:BED_MESH:START"
+    {% if "xyz" not in printer.toolhead.homed_axes %}
+        G28
+    {% endif %}
+    BED_MESH_CLEAR
+    BED_MESH_CALIBRATE
+    RESPOND MSG="QC:BED_MESH:PASS"
+
+# === CLEANUP ===
+
+[gcode_macro QC_CLEANUP]
+description: QC - Cooldown and disable motors
+gcode:
+    RESPOND MSG="QC:CLEANUP:START"
+    M104 S0
+    M140 S0
+    M106 S0
+    G28
+    M84
+    RESPOND MSG="QC:CLEANUP:PASS"
+
+# === SAVE ALL (after PID) ===
+
+[gcode_macro QC_SAVE]
+description: QC - Save config (triggers Klipper restart)
+gcode:
+    RESPOND MSG="QC:SAVE:START"
+    SAVE_CONFIG

--- a/qc/qc_wizard.py
+++ b/qc/qc_wizard.py
@@ -1,0 +1,488 @@
+"""
+QC Wizard Panel — KlipperScreen panel for factory quality control.
+Provides a step-by-step wizard with automated tests and visual confirmations.
+"""
+import gi
+import logging
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib, Pango
+
+from ks_includes.screen_panel import ScreenPanel
+
+logger = logging.getLogger("KlipperScreen.qc_wizard")
+
+# Import QC engine from ks_includes (symlinked there by install.sh)
+try:
+    from ks_includes.qc_engine import QCEngine, QCState, QCResult, QC_TESTS
+except ImportError:
+    # Fallback: try relative import for development
+    import sys
+    import os
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from qc_engine import QCEngine, QCState, QCResult, QC_TESTS
+
+
+class Panel(ScreenPanel):
+    def __init__(self, screen, title):
+        title = title or _("Quality Control")
+        super().__init__(screen, title)
+
+        self.engine = QCEngine()
+        self.engine.set_callbacks(
+            on_state_change=self._on_state_change,
+            on_test_complete=self._on_test_complete,
+            on_visual_prompt=self._on_visual_prompt,
+            on_qc_complete=self._on_qc_complete,
+        )
+        self._visual_dialog = None
+        self._current_report = None
+
+        # Build the UI
+        self._build_start_screen()
+
+    # ─── UI BUILDERS ────────────────────────────────────────────
+
+    def _build_start_screen(self):
+        self._clear_content()
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=20)
+        box.set_valign(Gtk.Align.CENTER)
+        box.set_halign(Gtk.Align.CENTER)
+        box.set_vexpand(True)
+
+        # Title
+        title_label = Gtk.Label()
+        title_label.set_markup("<span size='xx-large' weight='bold'>YUMI Quality Control</span>")
+        box.pack_start(title_label, False, False, 10)
+
+        # Info
+        info_label = Gtk.Label()
+        info_label.set_markup(
+            f"<span size='large'>{len(QC_TESTS)} tests — Homing, Motors, Fans, "
+            f"Temperature, PID, Bed Mesh</span>"
+        )
+        info_label.set_line_wrap(True)
+        info_label.set_max_width_chars(50)
+        info_label.set_justify(Gtk.Justification.CENTER)
+        box.pack_start(info_label, False, False, 5)
+
+        # Printer ID input
+        id_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        id_box.set_halign(Gtk.Align.CENTER)
+        id_label = Gtk.Label(label="Printer ID:")
+        id_label.set_markup("<span size='large'>Printer ID:</span>")
+        self.labels["printer_id"] = Gtk.Entry()
+        self.labels["printer_id"].set_placeholder_text("SP-2026-XXXXX")
+        self.labels["printer_id"].set_width_chars(20)
+        id_box.pack_start(id_label, False, False, 0)
+        id_box.pack_start(self.labels["printer_id"], False, False, 0)
+        box.pack_start(id_box, False, False, 10)
+
+        # Start button
+        start_btn = self._gtk.Button("resume", _("START QC"), "color3",
+                                     scale=self.bts * 1.5)
+        start_btn.connect("clicked", self._on_start_clicked)
+        start_btn.set_size_request(300, 80)
+        box.pack_start(start_btn, False, False, 20)
+
+        self.content.add(box)
+        self.content.show_all()
+
+    def _build_running_screen(self):
+        self._clear_content()
+
+        main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+
+        # Header with progress
+        header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        self.labels["test_name"] = Gtk.Label()
+        self.labels["test_name"].set_markup("<span size='large' weight='bold'>Initializing...</span>")
+        self.labels["test_name"].set_halign(Gtk.Align.START)
+        self.labels["test_name"].set_hexpand(True)
+
+        self.labels["progress"] = Gtk.Label()
+        self.labels["progress"].set_markup("<span size='large'>0 / {}</span>".format(len(QC_TESTS)))
+        self.labels["progress"].set_halign(Gtk.Align.END)
+
+        header.pack_start(self.labels["test_name"], True, True, 5)
+        header.pack_end(self.labels["progress"], False, False, 5)
+        main_box.pack_start(header, False, False, 5)
+
+        # Progress bar
+        self.labels["progress_bar"] = Gtk.ProgressBar()
+        self.labels["progress_bar"].set_fraction(0)
+        self.labels["progress_bar"].set_show_text(True)
+        main_box.pack_start(self.labels["progress_bar"], False, False, 5)
+
+        # Status indicator
+        self.labels["status"] = Gtk.Label()
+        self.labels["status"].set_markup("<span size='large'>Running...</span>")
+        self.labels["status"].set_halign(Gtk.Align.START)
+        main_box.pack_start(self.labels["status"], False, False, 5)
+
+        # Scrollable test log
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_vexpand(True)
+
+        self.labels["log_box"] = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        scroll.add(self.labels["log_box"])
+        main_box.pack_start(scroll, True, True, 5)
+
+        # Bottom buttons
+        btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+
+        abort_btn = self._gtk.Button("stop", _("Abort"), "color2")
+        abort_btn.connect("clicked", self._on_abort_clicked)
+        btn_box.pack_start(abort_btn, True, True, 0)
+
+        skip_btn = self._gtk.Button("arrow-right", _("Skip Test"), "color1")
+        skip_btn.connect("clicked", self._on_skip_clicked)
+        btn_box.pack_end(skip_btn, True, True, 0)
+
+        main_box.pack_end(btn_box, False, False, 5)
+
+        self.content.add(main_box)
+        self.content.show_all()
+
+    def _build_summary_screen(self, report):
+        self._clear_content()
+
+        main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+
+        # Overall result header
+        overall = report.get("overall_result", "UNKNOWN")
+        if overall == "PASS":
+            color = "#4CAF50"
+            icon = "complete"
+        elif overall == "FAIL":
+            color = "#F44336"
+            icon = "cancel"
+        else:
+            color = "#FF9800"
+            icon = "warning"
+
+        result_label = Gtk.Label()
+        result_label.set_markup(
+            f"<span size='xx-large' weight='bold' foreground='{color}'>"
+            f"QC {overall}</span>"
+        )
+        main_box.pack_start(result_label, False, False, 10)
+
+        # Info line
+        duration = report.get("duration_seconds", 0)
+        mins = duration // 60
+        secs = duration % 60
+        info_label = Gtk.Label()
+        info_label.set_markup(
+            f"<span size='large'>Printer: {report.get('printer_id', '?')} — "
+            f"Duration: {mins}m {secs}s</span>"
+        )
+        main_box.pack_start(info_label, False, False, 5)
+
+        # Test results grid (scrollable)
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_vexpand(True)
+
+        results_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+        for test in report.get("tests", []):
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+            row.set_margin_start(10)
+            row.set_margin_end(10)
+
+            result = test.get("result", "pending")
+            if result == "pass":
+                mark = "<span foreground='#4CAF50' size='large' weight='bold'>  PASS</span>"
+            elif result == "fail":
+                mark = "<span foreground='#F44336' size='large' weight='bold'>  FAIL</span>"
+            elif result == "skipped":
+                mark = "<span foreground='#FF9800' size='large' weight='bold'>  SKIP</span>"
+            else:
+                mark = "<span foreground='#9E9E9E' size='large'>  ---</span>"
+
+            name_label = Gtk.Label()
+            name_label.set_markup(f"<span size='large'>{test['name']}</span>")
+            name_label.set_halign(Gtk.Align.START)
+            name_label.set_hexpand(True)
+
+            result_lbl = Gtk.Label()
+            result_lbl.set_markup(mark)
+            result_lbl.set_halign(Gtk.Align.END)
+
+            row.pack_start(name_label, True, True, 0)
+            row.pack_end(result_lbl, False, False, 0)
+            results_box.pack_start(row, False, False, 0)
+
+        scroll.add(results_box)
+        main_box.pack_start(scroll, True, True, 5)
+
+        # Bottom buttons
+        btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+
+        save_btn = self._gtk.Button("sd", _("Save Report"), "color3")
+        save_btn.connect("clicked", self._on_save_report)
+        btn_box.pack_start(save_btn, True, True, 0)
+
+        upload_btn = self._gtk.Button("network", _("Upload"), "color4")
+        upload_btn.connect("clicked", self._on_upload_report)
+        btn_box.pack_start(upload_btn, True, True, 0)
+
+        new_btn = self._gtk.Button("refresh", _("New QC"), "color1")
+        new_btn.connect("clicked", self._on_new_qc)
+        btn_box.pack_start(new_btn, True, True, 0)
+
+        main_box.pack_end(btn_box, False, False, 5)
+
+        self.content.add(main_box)
+        self.content.show_all()
+
+    # ─── VISUAL CONFIRMATION DIALOG ────────────────────────────
+
+    def _show_visual_dialog(self, test):
+        """Show a full-screen Yes/No dialog for visual confirmation."""
+        if self._visual_dialog:
+            self._gtk.remove_dialog(self._visual_dialog)
+            self._visual_dialog = None
+
+        prompt = test.get("prompt", f"Test {test['name']} OK ?")
+
+        # Build dialog content
+        content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=20)
+        content_box.set_valign(Gtk.Align.CENTER)
+
+        # Test name
+        name_label = Gtk.Label()
+        name_label.set_markup(
+            f"<span size='x-large' weight='bold'>{test['name']}</span>"
+        )
+        content_box.pack_start(name_label, False, False, 10)
+
+        # Question
+        question_label = Gtk.Label()
+        question_label.set_markup(f"<span size='xx-large'>{prompt}</span>")
+        question_label.set_line_wrap(True)
+        question_label.set_max_width_chars(40)
+        question_label.set_justify(Gtk.Justification.CENTER)
+        content_box.pack_start(question_label, False, False, 20)
+
+        buttons = [
+            {"name": _("YES"), "response": Gtk.ResponseType.YES,
+             "style": "color3"},
+            {"name": _("NO"), "response": Gtk.ResponseType.NO,
+             "style": "color2"},
+        ]
+
+        self._visual_dialog = self._gtk.Dialog(
+            _("Visual Check"),
+            buttons,
+            content_box,
+            self._on_visual_dialog_response,
+        )
+
+    def _on_visual_dialog_response(self, dialog, response_id):
+        self._gtk.remove_dialog(dialog)
+        self._visual_dialog = None
+
+        passed = (response_id == Gtk.ResponseType.YES)
+        self.engine.record_visual_result(passed)
+
+    # ─── EVENT HANDLERS ────────────────────────────────────────
+
+    def _on_start_clicked(self, widget):
+        printer_id = self.labels["printer_id"].get_text().strip()
+        if not printer_id:
+            self._screen.show_popup_message(
+                "Please enter a Printer ID", level=2
+            )
+            return
+
+        self._build_running_screen()
+        test = self.engine.start(printer_id)
+        if test:
+            self._run_test(test)
+
+    def _on_abort_clicked(self, widget):
+        # Confirm abort
+        label = Gtk.Label()
+        label.set_markup("<span size='large'>Abort QC protocol?</span>")
+        buttons = [
+            {"name": _("Yes, Abort"), "response": Gtk.ResponseType.YES,
+             "style": "color2"},
+            {"name": _("Continue"), "response": Gtk.ResponseType.NO},
+        ]
+        self._gtk.Dialog(_("Confirm Abort"), buttons, label,
+                         self._on_abort_confirmed)
+
+    def _on_abort_confirmed(self, dialog, response_id):
+        self._gtk.remove_dialog(dialog)
+        if response_id == Gtk.ResponseType.YES:
+            # Stop fans/heaters before aborting
+            self._screen._ws.klippy.gcode_script("QC_CLEANUP")
+            self.engine.abort()
+
+    def _on_skip_clicked(self, widget):
+        if self._visual_dialog:
+            self._gtk.remove_dialog(self._visual_dialog)
+            self._visual_dialog = None
+        self.engine.skip_current_test()
+
+    def _on_save_report(self, widget):
+        if self._current_report:
+            path = self.engine.save_report(self._current_report)
+            self._screen.show_popup_message(
+                f"Report saved: {path}", level=1
+            )
+
+    def _on_upload_report(self, widget):
+        if not self._current_report:
+            return
+        # Save first, then upload
+        path = self.engine.save_report(self._current_report)
+        try:
+            import requests
+            r = requests.post(
+                "https://app.yumi-lab.com/api/qc/report",
+                json=self._current_report,
+                timeout=15,
+            )
+            if r.status_code == 200:
+                self._screen.show_popup_message("Report uploaded!", level=1)
+            else:
+                self._screen.show_popup_message(
+                    f"Upload failed: HTTP {r.status_code}", level=3
+                )
+        except Exception as e:
+            self._screen.show_popup_message(f"Upload error: {e}", level=3)
+
+    def _on_new_qc(self, widget):
+        self._current_report = None
+        self._build_start_screen()
+
+    # ─── ENGINE CALLBACKS ──────────────────────────────────────
+
+    def _on_state_change(self, old_state, new_state):
+        GLib.idle_add(self._update_status_label, new_state)
+
+    def _on_test_complete(self, test_id, result):
+        GLib.idle_add(self._add_log_entry, test_id, result)
+        # Run next test if available
+        test = self.engine.get_current_test()
+        if test and self.engine.state == QCState.RUNNING:
+            GLib.idle_add(self._run_test, test)
+
+    def _on_visual_prompt(self, test):
+        # Stop part fan after visual check (it was turned on by the macro)
+        GLib.idle_add(self._show_visual_dialog, test)
+
+    def _on_qc_complete(self, report):
+        self._current_report = report
+        # Cleanup: stop heaters/fans/motors
+        self._screen._ws.klippy.gcode_script("QC_CLEANUP")
+        GLib.idle_add(self._build_summary_screen, report)
+
+    # ─── TEST EXECUTION ────────────────────────────────────────
+
+    def _run_test(self, test):
+        """Send the macro for the current test."""
+        self._update_test_display(test)
+        macro = test.get("macro", "")
+        if macro:
+            self._screen._ws.klippy.gcode_script(macro)
+
+    def _update_test_display(self, test):
+        current, total = self.engine.get_progress()
+        if "test_name" in self.labels:
+            self.labels["test_name"].set_markup(
+                f"<span size='large' weight='bold'>{test['name']}</span>"
+            )
+        if "progress" in self.labels:
+            self.labels["progress"].set_markup(
+                f"<span size='large'>{current} / {total}</span>"
+            )
+        if "progress_bar" in self.labels:
+            self.labels["progress_bar"].set_fraction(current / total)
+            self.labels["progress_bar"].set_text(f"{current}/{total}")
+
+    def _update_status_label(self, state):
+        status_map = {
+            QCState.RUNNING: "Running...",
+            QCState.WAITING_GCODE: "Waiting for test result...",
+            QCState.WAITING_VISUAL: "Waiting for visual confirmation...",
+            QCState.COMPLETED: "QC Complete!",
+            QCState.ABORTED: "QC Aborted",
+        }
+        text = status_map.get(state, str(state.value))
+        if "status" in self.labels:
+            self.labels["status"].set_markup(f"<span size='large'>{text}</span>")
+
+    def _add_log_entry(self, test_id, result):
+        """Add a result line to the scrollable log."""
+        if "log_box" not in self.labels:
+            return
+
+        # Find test name
+        test_name = test_id
+        for t in QC_TESTS:
+            if t["id"] == test_id:
+                test_name = t["name"]
+                break
+
+        if result == QCResult.PASS:
+            mark = "<span foreground='#4CAF50' weight='bold'>PASS</span>"
+        elif result == QCResult.FAIL:
+            mark = "<span foreground='#F44336' weight='bold'>FAIL</span>"
+        elif result == QCResult.SKIPPED:
+            mark = "<span foreground='#FF9800' weight='bold'>SKIP</span>"
+        else:
+            mark = "<span foreground='#9E9E9E'>---</span>"
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        row.set_margin_start(5)
+        row.set_margin_end(5)
+
+        name_lbl = Gtk.Label()
+        name_lbl.set_markup(f"<span size='medium'>{test_name}</span>")
+        name_lbl.set_halign(Gtk.Align.START)
+        name_lbl.set_hexpand(True)
+
+        result_lbl = Gtk.Label()
+        result_lbl.set_markup(mark)
+        result_lbl.set_halign(Gtk.Align.END)
+
+        row.pack_start(name_lbl, True, True, 0)
+        row.pack_end(result_lbl, False, False, 0)
+        row.show_all()
+
+        self.labels["log_box"].pack_start(row, False, False, 0)
+
+        # Auto-scroll to bottom
+        parent = self.labels["log_box"].get_parent()
+        if parent and hasattr(parent, "get_vadjustment"):
+            adj = parent.get_vadjustment()
+            GLib.idle_add(lambda: adj.set_value(adj.get_upper()))
+
+    # ─── KLIPPERSCREEN LIFECYCLE ───────────────────────────────
+
+    def activate(self):
+        """Called when panel becomes visible."""
+        pass
+
+    def process_update(self, action, data):
+        """Process printer state updates from KlipperScreen."""
+        if action == "notify_gcode_response":
+            if isinstance(data, str):
+                self.engine.process_gcode_response(data)
+            elif isinstance(data, list):
+                for msg in data:
+                    if isinstance(msg, str):
+                        self.engine.process_gcode_response(msg)
+        return False
+
+    # ─── HELPERS ───────────────────────────────────────────────
+
+    def _clear_content(self):
+        """Remove all children from the content container."""
+        for child in self.content.get_children():
+            self.content.remove(child)


### PR DESCRIPTION
## Summary
- Complete quality control protocol for factory 3D printer testing
- KlipperScreen GTK3 panel with step-by-step wizard (17 tests)
- Automated tests (homing, temperature, PID, bed mesh) + visual confirmations (fans, motor direction) with YES/NO dialogs
- JSON report generation + upload to Yumi Lab server
- Deployed via symlinks in install.sh, auto-updated by Moonraker

## Files
- `qc/qc_macros.cfg` — Klipper gcode macros for each QC test
- `qc/qc_engine.py` — State machine, test definitions, report generator
- `qc/qc_wizard.py` — KlipperScreen panel (4 screens: start, running, visual dialog, summary)
- `qc/qc-check.svg` — Menu icon
- `install.sh` — QC deployment section added

## Test plan
- [ ] Flash SmartPad, run `cd ~/yumi-config && ./install.sh`
- [ ] Verify symlinks: `ls -la ~/KlipperScreen/panels/qc_wizard.py`
- [ ] KlipperScreen > More > Quality Control
- [ ] Run full QC wizard, test YES/NO dialogs
- [ ] Check report in `~/printer_data/config/qc_reports/`