### PR TITLE
Generate printer.cfg from the detected boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # yumi-config
 cfg files for YUMI products
+
+## printer.cfg from the detected hardware (`generator/`)
+
+A pad configures itself from the boards that are plugged in:
+
+```
+generator/autoconfig.py [--dry-run] [--factory] [--minimal]
+```
+
+1. `yumi-detect.py` (with Klipper stopped) reads the `YUMI_CONFIG` descriptor burned in every
+   MCU firmware over its serial port (RJ11 main board, smartbox, USB) and writes the composition
+   to `~/.yumi_composition.json` — facts only, no decision.
+2. `compose.py` turns it into a product of `YUMI-LAB_product-catalog.json`: `device=` gives the
+   machine (C235/C335/C435), a HyperDrive board present means CHROMAX X12 + 7 YMS Pro, print head
+   type and nozzle come from `printer_data/config/.yumi_product_prefs.json` (defaults in the
+   catalog's `detection` section). The ports that answered are injected into `[mcu]` /
+   `[mcu smartbox]`, then `printer.cfg` is written (previous one kept as
+   `printer-<ts>-autoconfig.cfg`) and the state saved in `.detected_hardware.json`.
+3. Policy: same main board (uid) → the `SAVE_CONFIG` block is preserved; different board →
+   factory cfg; no main board → alert, nothing touched (exit 2); no matching product → minimal cfg
+   (`[mcu]` sections + `kinematics: none`) so Klipper still connects (exit 3); identical cfg → exit 4.
+
+Klipper is stopped and started through Moonraker's API (no sudo needed). Everything that decides
+is data in the catalog (`detection`), not code. Tests: `python3 -m unittest discover -s generator/tests`.

--- a/generator/YUMI-LAB_product-catalog.json
+++ b/generator/YUMI-LAB_product-catalog.json
@@ -10,6 +10,17 @@
     { "id": "yms",         "label": "YMS System",      "priority": 5 },
     { "id": "accessory",   "label": "Accessories",     "priority": 6 }
   ],
+  "detection": {
+    "_doc": "Rules used by compose.py to turn the hardware composition (yumi-detect.py: boards read from the YUMI_CONFIG descriptor burned in each MCU firmware) into a product of this catalog. Descriptor fields: board= cpu= conn= device= x/y/z/e0/e1= mx/my/mz= piezo= lot= uid=. Machines are the components of layer 'machine' (device= is their id).",
+    "main_boards": { "SMART_MAKER_1_X": "SMART_MAKER_1X" },
+    "smartbox_devices": ["HYPERDRIVE_3P2L"],
+    "with_smartbox": { "hotend": "CHROMAX_X12", "yms": "YMS_7_PRO" },
+    "chromax_without_smartbox_yms": "YMS_2_LITE",
+    "defaults": { "hotend": "DIRECT_DRIVE", "hotend_type": "LOW_WASTE", "nozzle": "NOZZLE_04" },
+    "prefs_file": ".yumi_product_prefs.json",
+    "state_file": ".detected_hardware.json",
+    "backup_pattern": "printer-{ts}-autoconfig.cfg"
+  },
 
   "components": {
 

--- a/generator/autoconfig.py
+++ b/generator/autoconfig.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+autoconfig — one shot on the pad: stop Klipper, scan the boards, compose printer.cfg, start Klipper.
+
+    autoconfig.py [--dry-run] [--factory] [--minimal] [PORT ...]
+
+Service control goes through Moonraker's API (the pi user has no passwordless sudo on the
+pads), with a systemctl fallback when Moonraker is down. The ports probed are the UART ports
+the catalog knows (every `serial` of its components: RJ11 main board, smartbox) plus whatever
+yumi-scan finds on USB. Prints compose's JSON summary; exit code = compose's.
+"""
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import generator  # noqa: E402
+
+MOONRAKER = "http://127.0.0.1:7125"
+KLIPPER_SERVICE = "klipper"
+
+
+def catalog_uart_ports(catalog):
+    """Every fixed serial port declared in the catalog (main board RJ11, smartbox...)."""
+    ports = []
+    for comp in catalog["components"].values():
+        if not isinstance(comp, dict):
+            continue
+        for key in ("mcu", "smartbox"):
+            serial = (comp.get(key) or {}).get("serial")
+            if serial and serial.startswith("/dev/ttyS") and serial not in ports:
+                ports.append(serial)
+    return ports
+
+
+def moonraker(method, path):
+    req = urllib.request.Request(MOONRAKER + path, method=method)
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.load(r)
+
+
+def service(action):
+    """stop/start Klipper via Moonraker, else systemctl (works when run as root)."""
+    try:
+        moonraker("POST", "/machine/services/%s?service=%s" % (action, KLIPPER_SERVICE))
+        return "moonraker"
+    except Exception:
+        subprocess.run(["systemctl", action, KLIPPER_SERVICE], check=False)
+        return "systemctl"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Detect the boards and install the matching printer.cfg")
+    ap.add_argument("ports", nargs="*", help="extra serial ports to probe")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--factory", action="store_true")
+    ap.add_argument("--minimal", action="store_true")
+    a = ap.parse_args()
+
+    catalog = generator.load_catalog()
+    ports = catalog_uart_ports(catalog) + [p for p in a.ports if p not in catalog_uart_ports(catalog)]
+
+    how = service("stop")
+    time.sleep(2)  # let klippy release the ports
+    try:
+        detect = subprocess.run([sys.executable, str(HERE / "yumi-detect.py"), *ports],
+                                capture_output=True, text=True, timeout=240)
+        sys.stderr.write(detect.stdout + detect.stderr)
+        compose_cmd = [sys.executable, str(HERE / "compose.py")]
+        for flag in ("dry_run", "factory", "minimal"):
+            if getattr(a, flag):
+                compose_cmd.append("--" + flag.replace("_", "-"))
+        comp = subprocess.run(compose_cmd, capture_output=True, text=True, timeout=120)
+        sys.stderr.write(comp.stderr)
+        print(comp.stdout.strip())
+        code = comp.returncode
+    finally:
+        service("start")
+    sys.stderr.write("klipper stopped/started via %s\n" % how)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/generator/autoconfig.py
+++ b/generator/autoconfig.py
@@ -2,12 +2,16 @@
 """
 autoconfig — one shot on the pad: stop Klipper, scan the boards, compose printer.cfg, start Klipper.
 
-    autoconfig.py [--dry-run] [--factory] [--minimal] [PORT ...]
+    autoconfig.py [--boot] [--dry-run] [--factory] [--minimal] [PORT ...]
 
-Service control goes through Moonraker's API (the pi user has no passwordless sudo on the
-pads), with a systemctl fallback when Moonraker is down. The ports probed are the UART ports
-the catalog knows (every `serial` of its components: RJ11 main board, smartbox) plus whatever
-yumi-scan finds on USB. Prints compose's JSON summary; exit code = compose's.
+At boot, yumi-autoconfig.service (Before=klipper.service) runs this with --boot: Klipper is
+not started yet, the ports are free, no service is touched — the scan happens once, and
+compose.py leaves printer.cfg alone when the boards have not changed. Run by hand while
+Klipper is up, it stops Klipper through Moonraker's API (the pi user has no passwordless sudo
+on the pads; systemctl as a fallback) and starts it again afterwards. The ports probed are
+the UART ports the catalog knows (every `serial` of its components: RJ11 main board,
+smartbox) plus whatever yumi-scan finds on USB. Prints compose's JSON summary; exit code =
+compose's.
 """
 import argparse
 import json
@@ -54,9 +58,15 @@ def service(action):
         return "systemctl"
 
 
+def klipper_active():
+    return subprocess.run(["systemctl", "is-active", "--quiet", KLIPPER_SERVICE]).returncode == 0
+
+
 def main():
     ap = argparse.ArgumentParser(description="Detect the boards and install the matching printer.cfg")
     ap.add_argument("ports", nargs="*", help="extra serial ports to probe")
+    ap.add_argument("--boot", action="store_true",
+                    help="boot mode (yumi-autoconfig.service): Klipper is not running, touch no service")
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--factory", action="store_true")
     ap.add_argument("--minimal", action="store_true")
@@ -65,8 +75,10 @@ def main():
     catalog = generator.load_catalog()
     ports = catalog_uart_ports(catalog) + [p for p in a.ports if p not in catalog_uart_ports(catalog)]
 
-    how = service("stop")
-    time.sleep(2)  # let klippy release the ports
+    manage = not a.boot and klipper_active()
+    how = service("stop") if manage else "none (klipper not running)"
+    if manage:
+        time.sleep(2)  # let klippy release the ports
     try:
         detect = subprocess.run([sys.executable, str(HERE / "yumi-detect.py"), *ports],
                                 capture_output=True, text=True, timeout=240)
@@ -80,7 +92,8 @@ def main():
         print(comp.stdout.strip())
         code = comp.returncode
     finally:
-        service("start")
+        if manage:
+            service("start")
     sys.stderr.write("klipper stopped/started via %s\n" % how)
     return code
 

--- a/generator/compose.py
+++ b/generator/compose.py
@@ -18,6 +18,11 @@ The scanner is dumb and factual. Every decision lives here, driven by the
         no main board           ALERT     never destructive
         unknown product         MINIMAL   [mcu] sections + kinematics none, Klipper connects
 
+Runs at every boot (yumi-autoconfig.service, before Klipper): the boards are compared with
+the ones recorded in .detected_hardware.json and, when the hardware has not changed, nothing
+is generated and printer.cfg is not touched — a cfg edited by hand stays as it is until a
+board is added, removed or replaced. --factory forces a fresh cfg whatever the state.
+
 Exit codes: 0 applied, 2 alert (no usable main board), 3 minimal cfg written, 4 nothing to do.
 
 Usage:
@@ -87,6 +92,13 @@ def classify_boards(composition, catalog):
         else:
             others.append(b)
     return main, main_unknown, smartbox, others
+
+
+def hardware_fingerprint(composition):
+    """What identifies the machine: which board (uid, device) answers on which port.
+    Cameras are left out on purpose: plugging a webcam must not rewrite printer.cfg."""
+    return sorted((b.get("port") or "", b.get("uid") or "", b.get("device") or "")
+                  for b in composition.get("boards", []))
 
 
 def find_product(catalog, chain):
@@ -210,6 +222,15 @@ def build(composition, catalog, config_dir, prefs=None, factory=False, minimal=F
     summary = {"main": sel["main"], "smartbox": sel["smartbox"], "others": sel["others"],
                "product": sel["product"], "chain": sel["chain"], "reasons": sel["reasons"],
                "mode": None, "alert": sel["alert"], "minimal": False}
+
+    # Same boards on the same ports as last time -> the machine has not changed: leave
+    # printer.cfg alone (it may carry manual edits and calibrations), unless forced.
+    recorded = state.get("composition")
+    if (not factory and not minimal and recorded is not None and current is not None
+            and hardware_fingerprint(recorded) == hardware_fingerprint(composition)):
+        summary["mode"] = "unchanged"
+        summary["reasons"].append("same boards as recorded on %s: printer.cfg left untouched" % state.get("ts"))
+        return EXIT_UNCHANGED, summary, None
 
     if sel["alert"]:
         summary["mode"] = "alert"

--- a/generator/compose.py
+++ b/generator/compose.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+compose — from the hardware composition of a pad to the printer.cfg that matches it.
+
+    yumi-detect.py  ->  ~/.yumi_composition.json          facts only: boards, cameras
+    compose.py      ->  printer_data/config/printer.cfg    + .detected_hardware.json
+
+The scanner is dumb and factual. Every decision lives here, driven by the
+"detection" rules of YUMI-LAB_product-catalog.json:
+
+  - which catalog product the boards describe: the main board says device=C235/C335/C435,
+    a HyperDrive board present means CHROMAX X12 + 7 YMS Pro, the print head type and the
+    nozzle come from the user preferences file (defaults in the catalog);
+  - which serial ports go into [mcu] and [mcu smartbox]: the ones that actually answered;
+  - the policy against the previous state (.detected_hardware.json):
+        same main board (uid)   PRESERVE  keep the SAVE_CONFIG block of the current cfg
+        different main board    FACTORY   fresh cfg, calibrations dropped
+        no main board           ALERT     never destructive
+        unknown product         MINIMAL   [mcu] sections + kinematics none, Klipper connects
+
+Exit codes: 0 applied, 2 alert (no usable main board), 3 minimal cfg written, 4 nothing to do.
+
+Usage:
+    compose.py [--composition FILE] [--config-dir DIR] [--dry-run] [--factory] [--minimal]
+"""
+import argparse
+import datetime
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import generator  # noqa: E402  (load_catalog, generate, deep_merge)
+
+SAVE_CONFIG_MARKER = generator.render_save_config().splitlines()[0]
+DEFAULT_CONFIG_DIR = Path.home() / "printer_data" / "config"
+
+EXIT_APPLIED, EXIT_ALERT, EXIT_MINIMAL, EXIT_UNCHANGED = 0, 2, 3, 4
+
+
+def _yumi_detect_default_out():
+    """The composition file is owned by yumi-detect.py: read its DEFAULT_OUT, never retype it."""
+    spec = importlib.util.spec_from_file_location("yumi_detect", HERE / "yumi-detect.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return Path(mod.DEFAULT_OUT)
+
+
+def load_json(path, default):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return default
+
+
+# ─── Selection: composition -> product ──────────────────────────────
+
+def classify_boards(composition, catalog):
+    """Split the detected boards into main board, smartbox and the rest."""
+    rules = catalog["detection"]
+    machines = {k for k, v in catalog["components"].items()
+                if isinstance(v, dict) and v.get("layer") == "machine"}
+    main, main_unknown, smartbox, others = None, None, None, []
+    for b in composition.get("boards", []):
+        # A HyperDrive is a Smart Maker board flashed as device=HYPERDRIVE_3P2L: the device
+        # decides, so the smartbox test comes before the main-board one.
+        if b.get("device") in rules["smartbox_devices"]:
+            if smartbox is None:
+                smartbox = b
+            else:
+                others.append(b)
+        elif b.get("board") in rules["main_boards"]:
+            if b.get("device") in machines:
+                if main is None:
+                    main = b
+                else:
+                    others.append(b)
+            elif main_unknown is None:
+                main_unknown = b
+            else:
+                others.append(b)
+        else:
+            others.append(b)
+    return main, main_unknown, smartbox, others
+
+
+def find_product(catalog, chain):
+    wanted = set(chain)
+    for pid, prod in catalog["products"].items():
+        if isinstance(prod, dict) and set(prod.get("chain", [])) == wanted:
+            return pid
+    return None
+
+
+def select(composition, catalog, prefs=None):
+    """Decide what to generate. Returns a dict with product/chain/overrides or minimal/alert."""
+    prefs = prefs or {}
+    rules = catalog["detection"]
+    main, main_unknown, smartbox, others = classify_boards(composition, catalog)
+    sel = {"main": main, "smartbox": smartbox, "others": others,
+           "product": None, "chain": None, "overrides": None, "minimal": False, "alert": None,
+           "reasons": []}
+
+    if main is None:
+        if main_unknown is not None:
+            sel["main"] = main_unknown
+            sel["minimal"] = True
+            sel["reasons"].append("main board %s answers on %s but device=%r is not a machine of the catalog"
+                                  % (main_unknown.get("board"), main_unknown.get("port"), main_unknown.get("device")))
+        elif smartbox is not None:
+            sel["alert"] = "smartbox %s answers on %s but no main board does" % (smartbox.get("device"), smartbox.get("port"))
+        elif composition.get("boards"):
+            sel["alert"] = "boards answer but none is a known main board: %s" % ", ".join(
+                "%s@%s" % (b.get("device") or b.get("board") or "?", b.get("port")) for b in composition["boards"])
+        else:
+            sel["alert"] = "no MCU answered"
+        return sel
+
+    board_comp = rules["main_boards"][main["board"]]
+    defaults = rules["defaults"]
+    if smartbox is not None:
+        hotend, yms = rules["with_smartbox"]["hotend"], rules["with_smartbox"]["yms"]
+        sel["reasons"].append("smartbox %s on %s -> %s + %s" % (smartbox.get("device"), smartbox.get("port"), hotend, yms))
+    else:
+        hotend = prefs.get("hotend", defaults["hotend"])
+        yms = rules["chromax_without_smartbox_yms"] if hotend == rules["with_smartbox"]["hotend"] else None
+        sel["reasons"].append("no smartbox -> hotend %s (%s)" % (hotend, "preference" if "hotend" in prefs else "default"))
+    hotend_type = prefs.get("hotend_type", defaults["hotend_type"])
+    nozzle = prefs.get("nozzle", defaults["nozzle"])
+
+    chain = [board_comp, main["device"], hotend, hotend_type, nozzle] + ([yms] if yms else [])
+    product = find_product(catalog, chain)
+    sel["chain"] = chain
+    if product is None:
+        sel["minimal"] = True
+        sel["reasons"].append("no product in the catalog for chain %s" % " + ".join(chain))
+        return sel
+
+    overrides = {"mcu": {"serial": main["port"]}}
+    if smartbox is not None:
+        overrides["smartbox"] = {"serial": smartbox["port"]}
+    sel["product"] = product
+    sel["overrides"] = overrides
+    return sel
+
+
+# ─── Rendering ──────────────────────────────────────────────────────
+
+def render_minimal(sel, catalog, config_dir):
+    """[mcu] sections for the boards that answered + kinematics none: Klipper connects, nothing moves."""
+    main, smartbox = sel["main"], sel["smartbox"]
+    lines = ["# printer.cfg minimal — written by compose.py: the boards answer but no catalog",
+             "# product matches yet. Klipper connects so the boards can be read (DEVICE, TMC);",
+             "# nothing can move with this configuration.",
+             "# " + "; ".join(sel["reasons"]), ""]
+    if (Path(config_dir) / "yumi-device.cfg").exists():
+        lines += ["[include yumi-device.cfg]", ""]
+    lines += ["[mcu]", "serial: %s" % main["port"], "restart_method: command", ""]
+    if smartbox is not None:
+        board_comp = catalog["detection"]["main_boards"].get(main.get("board"))
+        sb = catalog["components"].get(board_comp, {}).get("smartbox", {}) if board_comp else {}
+        lines += ["[mcu %s]" % sb.get("mcu_name", "smartbox"), "serial: %s" % smartbox["port"],
+                  "restart_method: command", ""]
+    lines += ["[printer]", "kinematics: none", "max_velocity: 1", "max_accel: 1", ""]
+    return "\n".join(lines)
+
+
+def save_config_block(cfg_text):
+    """The SAVE_CONFIG block of an existing printer.cfg (marker to end of file), or None."""
+    if not cfg_text:
+        return None
+    i = cfg_text.find(SAVE_CONFIG_MARKER)
+    return cfg_text[i:] if i >= 0 else None
+
+
+def with_save_config(cfg_text, block):
+    """Replace the empty SAVE_CONFIG tail of a generated cfg with a preserved block."""
+    i = cfg_text.find(SAVE_CONFIG_MARKER)
+    if i < 0 or not block:
+        return cfg_text
+    return cfg_text[:i] + block.rstrip("\n") + "\n"
+
+
+# ─── Apply ──────────────────────────────────────────────────────────
+
+def atomic_write(path, text):
+    tmp = str(path) + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(text)
+    os.replace(tmp, path)
+
+
+def build(composition, catalog, config_dir, prefs=None, factory=False, minimal=False):
+    """Everything but the disk writes: returns (exit_code, summary, new_cfg_text or None)."""
+    config_dir = Path(config_dir)
+    rules = catalog["detection"]
+    state = load_json(config_dir / rules["state_file"], {}) or {}
+    current = None
+    try:
+        current = (config_dir / "printer.cfg").read_text(encoding="utf-8")
+    except OSError:
+        pass
+
+    sel = select(composition, catalog, prefs)
+    summary = {"main": sel["main"], "smartbox": sel["smartbox"], "others": sel["others"],
+               "product": sel["product"], "chain": sel["chain"], "reasons": sel["reasons"],
+               "mode": None, "alert": sel["alert"], "minimal": False}
+
+    if sel["alert"]:
+        summary["mode"] = "alert"
+        return EXIT_ALERT, summary, None
+
+    if minimal or sel["minimal"]:
+        summary["minimal"] = True
+        summary["mode"] = "minimal"
+        return EXIT_MINIMAL, summary, render_minimal(sel, catalog, config_dir)
+
+    prev_uid = (state.get("main") or {}).get("uid")
+    new_uid = sel["main"].get("uid")
+    if factory:
+        mode = "factory"
+    elif prev_uid and new_uid and prev_uid != new_uid:
+        mode = "factory"
+        sel["reasons"].append("main board changed (uid %s -> %s): factory reset" % (prev_uid, new_uid))
+    else:
+        mode = "preserve"
+    summary["mode"] = mode
+
+    cfg = generator.generate(sel["product"], sel["overrides"])
+    if mode == "preserve":
+        block = save_config_block(current)
+        if block:
+            cfg = with_save_config(cfg, block)
+            sel["reasons"].append("SAVE_CONFIG block preserved")
+    if current is not None and cfg == current:
+        return EXIT_UNCHANGED, summary, cfg
+    return EXIT_APPLIED, summary, cfg
+
+
+def apply(composition, catalog, config_dir, prefs=None, factory=False, minimal=False, dry_run=False):
+    config_dir = Path(config_dir)
+    rules = catalog["detection"]
+    code, summary, cfg = build(composition, catalog, config_dir, prefs, factory, minimal)
+    summary["dry_run"] = dry_run
+    summary["written"] = False
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    if cfg is not None and code in (EXIT_APPLIED, EXIT_MINIMAL) and not dry_run:
+        target = config_dir / "printer.cfg"
+        if target.exists():
+            backup = config_dir / rules["backup_pattern"].format(ts=ts)
+            os.replace(target, backup)
+            summary["backup"] = str(backup)
+        atomic_write(target, cfg)
+        summary["written"] = True
+
+    if not dry_run:
+        state = {"ts": ts, "main": summary["main"], "smartbox": summary["smartbox"],
+                 "product": summary["product"], "chain": summary["chain"], "mode": summary["mode"],
+                 "cfg_sha256": hashlib.sha256(cfg.encode()).hexdigest() if cfg else None,
+                 "composition": composition}
+        atomic_write(config_dir / rules["state_file"], json.dumps(state, ensure_ascii=False, indent=2) + "\n")
+    return code, summary
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Compose printer.cfg from the detected hardware")
+    ap.add_argument("--composition", default=None,
+                    help="composition JSON written by yumi-detect.py (default: its own output file)")
+    ap.add_argument("--config-dir", default=str(DEFAULT_CONFIG_DIR))
+    ap.add_argument("--prefs", default=None, help="user preferences JSON (default: <config-dir>/<detection.prefs_file>)")
+    ap.add_argument("--factory", action="store_true", help="drop the SAVE_CONFIG block even if the main board is the same")
+    ap.add_argument("--minimal", action="store_true", help="write the minimal connect-only cfg whatever the product")
+    ap.add_argument("--dry-run", action="store_true", help="decide and report, write nothing")
+    args = ap.parse_args()
+
+    catalog = generator.load_catalog()
+    comp_path = Path(args.composition) if args.composition else _yumi_detect_default_out()
+    composition = load_json(comp_path, None)
+    if composition is None:
+        print(json.dumps({"mode": "alert", "alert": "composition file missing or invalid: %s" % comp_path}))
+        return EXIT_ALERT
+    prefs_path = Path(args.prefs) if args.prefs else Path(args.config_dir) / catalog["detection"]["prefs_file"]
+    prefs = load_json(prefs_path, {}) or {}
+
+    code, summary = apply(composition, catalog, args.config_dir, prefs, args.factory, args.minimal, args.dry_run)
+    print(json.dumps(summary, ensure_ascii=False))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -126,20 +126,34 @@ def render_probe_pressure(p):
     if not p.get('features', {}).get('probe_pressure'):
         return ""
     pp = p.get('probe_pressure', {})
+    # yumi_z_tap taps at [bed_mesh] zero_reference_position by default (mesh-zero
+    # mode). In that mode the extra does not read pressure_switch_x/y, and Klipper
+    # refuses unread options ("Option 'pressure_switch_x' is not valid"): only a
+    # machine with a dedicated switch off the bed (tap_at_bed_mesh_zero_position:
+    # false in the catalog) gets the switch coordinates.
+    switch_mode = pp.get('tap_at_bed_mesh_zero_position') is False \
+        or not p.get('bed_mesh', {}).get('zero_reference_position')
+    tap_lines = []
+    if switch_mode:
+        if pp.get('tap_at_bed_mesh_zero_position') is False:
+            tap_lines.append("tap_at_bed_mesh_zero_position: False")
+        tap_lines.append(f"pressure_switch_x: {pp.get('z_calc_switch_x', 49.5)}")
+        tap_lines.append(f"pressure_switch_y: {pp.get('z_calc_switch_y', 175.5)}")
+    tap_lines += [
+        f"compression_offset: {pp.get('compression_offset', 0.3)}",
+        f"max_probe_times: {pp.get('max_probe_times', 50)}",
+        f"probe_delay: {pp.get('probe_delay', 2)}",
+        f"z_hop: {pp.get('z_hop', 3)}",
+        f"samples: {pp.get('samples', 5)}",
+        f"samples_tolerance: {pp.get('samples_tolerance', 0.01)}",
+    ]
     return f"""[probe_pressure]
 pin: {pp.get('pin', '!PB7')}
 speed: {pp.get('speed', 6.0)}
 lift_speed: {pp.get('lift_speed', 6)}
 
 [yumi_z_tap]
-pressure_switch_x: {pp.get('z_calc_switch_x', 49.5)}
-pressure_switch_y: {pp.get('z_calc_switch_y', 175.5)}
-compression_offset: {pp.get('compression_offset', 0.3)}
-max_probe_times: {pp.get('max_probe_times', 50)}
-probe_delay: {pp.get('probe_delay', 2)}
-z_hop: {pp.get('z_hop', 3)}
-samples: {pp.get('samples', 5)}
-samples_tolerance: {pp.get('samples_tolerance', 0.01)}"""
+""" + "\n".join(tap_lines)
 
 
 def render_motor_constants(p):

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -726,8 +726,17 @@ def render_save_config():
 
 # ─── Assembler ──────────────────────────────────────────────────────
 
-def generate(product_id):
+def generate(product_id, overrides=None):
+    """Render the printer.cfg of a catalog product.
+
+    overrides: optional dict deep-merged over the resolved product, used by
+    compose.py to inject the serial ports actually detected on the pad
+    (e.g. {"mcu": {"serial": "/dev/serial/by-id/..."}}) without touching
+    the catalog defaults.
+    """
     p = resolve_product(product_id)
+    if overrides:
+        p = deep_merge(p, overrides)
     yms = p.get('yms_count', 0)
 
     sections = [

--- a/generator/tests/test_compose.py
+++ b/generator/tests/test_compose.py
@@ -1,0 +1,156 @@
+"""compose.py — composition -> product -> printer.cfg (stdlib unittest, no hardware)."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+import compose      # noqa: E402
+import generator    # noqa: E402
+
+CATALOG = generator.load_catalog()
+
+
+def board(port, device, uid, kind="main"):
+    """A board entry as yumi-detect.py reports it."""
+    if kind == "main":
+        return {"port": port, "uid": uid, "board": "SMART_MAKER_1_X", "cpu": "STM32F401",
+                "device": device, "conn": "UART", "lot": "202607",
+                "drivers": {"x": "SMART_TMC2209_V2", "y": "SMART_TMC2209_V2", "z": "SMART_TMC2209_V2",
+                            "e0": "SMART_TMC2209_V2", "e1": "SMART_TMC2209_V2"},
+                "motors": {"x": "42BYGH3023-B-22DH", "y": "42BYGH3023-B-22DH", "z": "42BYGH2216-B-24DH"},
+                "piezo": None, "comment": None, "klipper": "v0.13.0", "descriptor": "board=SMART_MAKER_1_X;device=%s;uid=%s" % (device, uid)}
+    return {"port": port, "uid": uid, "board": "SMART_MAKER_1_X", "cpu": "STM32F401", "device": device,
+            "conn": "UART", "drivers": {}, "motors": {}, "piezo": None, "comment": None, "klipper": "v0.13.0",
+            "descriptor": "board=SMART_MAKER_1_X;device=%s;uid=%s" % (device, uid)}
+
+
+C235 = {"boards": [board("/dev/ttyS1", "C235", "aaaaaa")], "cameras": []}
+C235_HD = {"boards": [board("/dev/ttyS1", "C235", "aaaaaa"),
+                      board("/dev/ttyS2", "HYPERDRIVE_3P2L", "bbbbbb", kind="smartbox")], "cameras": []}
+SAVE_BLOCK = ("#*# <---------------------- SAVE_CONFIG ---------------------->\n"
+              "#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.\n"
+              "#*#\n#*# [probe]\n#*# z_offset = 1.234\n")
+
+
+class Select(unittest.TestCase):
+    def test_main_only_uses_defaults(self):
+        sel = compose.select(C235, CATALOG)
+        self.assertEqual(sel["product"], "C235_DD_LW_04")
+        self.assertEqual(sel["overrides"], {"mcu": {"serial": "/dev/ttyS1"}})
+        self.assertFalse(sel["minimal"])
+        self.assertIsNone(sel["alert"])
+
+    def test_smartbox_means_chromax_7yms(self):
+        sel = compose.select(C235_HD, CATALOG)
+        self.assertEqual(sel["product"], "C235_CX12_LW_04_7YMS")
+        self.assertEqual(sel["overrides"]["smartbox"], {"serial": "/dev/ttyS2"})
+
+    def test_prefs_chromax_without_smartbox_is_2yms(self):
+        sel = compose.select(C235, CATALOG, {"hotend": "CHROMAX_X12", "hotend_type": "HIGH_FLOW"})
+        self.assertEqual(sel["product"], "C235_CX12_HF_04_2YMS")
+
+    def test_usb_main_board_port_is_injected(self):
+        comp = {"boards": [board("/dev/serial/by-id/usb-Klipper_stm32f401xc_1234-if00", "C435", "cccccc")]}
+        sel = compose.select(comp, CATALOG)
+        self.assertEqual(sel["product"], "C435_DD_LW_04")
+        cfg = generator.generate(sel["product"], sel["overrides"])
+        self.assertIn("serial: /dev/serial/by-id/usb-Klipper_stm32f401xc_1234-if00", cfg)
+
+    def test_unknown_device_is_minimal(self):
+        comp = {"boards": [board("/dev/ttyS1", "C999", "dddddd")]}
+        sel = compose.select(comp, CATALOG)
+        self.assertTrue(sel["minimal"])
+        self.assertIsNone(sel["product"])
+
+    def test_no_boards_is_alert(self):
+        self.assertEqual(compose.select({"boards": []}, CATALOG)["alert"], "no MCU answered")
+
+    def test_smartbox_alone_is_alert(self):
+        comp = {"boards": [board("/dev/ttyS2", "HYPERDRIVE_3P2L", "bbbbbb", kind="smartbox")]}
+        self.assertIn("no main board", compose.select(comp, CATALOG)["alert"])
+
+
+class Build(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _state(self, uid):
+        (self.dir / CATALOG["detection"]["state_file"]).write_text(json.dumps({"main": {"uid": uid}}))
+
+    def test_fresh_pad_generates_and_keeps_existing_save_config(self):
+        (self.dir / "printer.cfg").write_text("[mcu]\nserial: /dev/ttyACM0\n" + SAVE_BLOCK)
+        code, summary, cfg = compose.build(C235, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+        self.assertEqual(summary["mode"], "preserve")
+        self.assertIn("z_offset = 1.234", cfg)
+        self.assertIn("serial: /dev/ttyS1", cfg)
+        self.assertEqual(cfg.count(compose.SAVE_CONFIG_MARKER), 1)
+
+    def test_same_board_preserves(self):
+        self._state("aaaaaa")
+        (self.dir / "printer.cfg").write_text(SAVE_BLOCK)
+        code, summary, cfg = compose.build(C235, CATALOG, self.dir)
+        self.assertEqual(summary["mode"], "preserve")
+        self.assertIn("z_offset = 1.234", cfg)
+
+    def test_other_board_is_factory(self):
+        self._state("ffffff")
+        (self.dir / "printer.cfg").write_text(SAVE_BLOCK)
+        code, summary, cfg = compose.build(C235, CATALOG, self.dir)
+        self.assertEqual(summary["mode"], "factory")
+        self.assertNotIn("z_offset = 1.234", cfg)
+        self.assertTrue(cfg.rstrip().endswith("#*#"))
+
+    def test_identical_cfg_is_unchanged(self):
+        code, summary, cfg = compose.build(C235, CATALOG, self.dir)
+        (self.dir / "printer.cfg").write_text(cfg)
+        code2, _, _ = compose.build(C235, CATALOG, self.dir)
+        self.assertEqual(code2, compose.EXIT_UNCHANGED)
+
+    def test_minimal_cfg_connects_only(self):
+        comp = {"boards": [board("/dev/ttyS1", "C999", "dddddd"),
+                           board("/dev/ttyS2", "HYPERDRIVE_3P2L", "bbbbbb", kind="smartbox")]}
+        code, summary, cfg = compose.build(comp, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_MINIMAL)
+        self.assertIn("[mcu]\nserial: /dev/ttyS1", cfg)
+        self.assertIn("[mcu smartbox]\nserial: /dev/ttyS2", cfg)
+        self.assertIn("kinematics: none", cfg)
+        self.assertNotIn("[stepper_x]", cfg)
+
+    def test_alert_writes_nothing(self):
+        (self.dir / "printer.cfg").write_text("keep me")
+        code, summary = compose.apply({"boards": []}, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_ALERT)
+        self.assertEqual((self.dir / "printer.cfg").read_text(), "keep me")
+        self.assertFalse(summary["written"])
+
+    def test_apply_backs_up_and_records_state(self):
+        (self.dir / "printer.cfg").write_text("old")
+        code, summary = compose.apply(C235_HD, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+        self.assertTrue(summary["written"])
+        self.assertEqual(Path(summary["backup"]).read_text(), "old")
+        state = json.loads((self.dir / CATALOG["detection"]["state_file"]).read_text())
+        self.assertEqual(state["product"], "C235_CX12_LW_04_7YMS")
+        self.assertEqual(state["main"]["uid"], "aaaaaa")
+        new = (self.dir / "printer.cfg").read_text()
+        self.assertIn("[mcu smartbox]\nserial: /dev/ttyS2", new)
+
+    def test_dry_run_writes_nothing(self):
+        (self.dir / "printer.cfg").write_text("old")
+        code, summary = compose.apply(C235, CATALOG, self.dir, dry_run=True)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+        self.assertEqual((self.dir / "printer.cfg").read_text(), "old")
+        self.assertFalse((self.dir / CATALOG["detection"]["state_file"]).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generator/tests/test_compose.py
+++ b/generator/tests/test_compose.py
@@ -109,6 +109,35 @@ class Build(unittest.TestCase):
         self.assertNotIn("z_offset = 1.234", cfg)
         self.assertTrue(cfg.rstrip().endswith("#*#"))
 
+    def test_same_boards_leave_printer_cfg_alone(self):
+        # first boot: cfg generated and state recorded
+        code, summary = compose.apply(C235, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+        # the operator edits the cfg by hand
+        (self.dir / "printer.cfg").write_text("# hand edited\n" + (self.dir / "printer.cfg").read_text())
+        # next boots: same boards -> untouched, nothing generated
+        code, summary = compose.apply(C235, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_UNCHANGED)
+        self.assertEqual(summary["mode"], "unchanged")
+        self.assertTrue((self.dir / "printer.cfg").read_text().startswith("# hand edited"))
+        # a board appears -> regenerated (hyperdrive => 7 YMS)
+        code, summary = compose.apply(C235_HD, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+        self.assertEqual(summary["product"], "C235_CX12_LW_04_7YMS")
+        # --factory bypasses the fingerprint (and reports "unchanged" only because
+        # the freshly generated cfg is byte-identical to the one just written)
+        code, summary = compose.apply(C235_HD, CATALOG, self.dir, factory=True)
+        self.assertEqual(summary["mode"], "factory")
+        self.assertEqual(code, compose.EXIT_UNCHANGED)
+        (self.dir / "printer.cfg").write_text("# hand edited again\n")
+        code, summary = compose.apply(C235_HD, CATALOG, self.dir, factory=True)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+
+    def test_fingerprint_ignores_cameras(self):
+        a = dict(C235, cameras=[])
+        b = dict(C235, cameras=[{"name": "cam"}])
+        self.assertEqual(compose.hardware_fingerprint(a), compose.hardware_fingerprint(b))
+
     def test_identical_cfg_is_unchanged(self):
         code, summary, cfg = compose.build(C235, CATALOG, self.dir)
         (self.dir / "printer.cfg").write_text(cfg)

--- a/generator/tests/test_compose.py
+++ b/generator/tests/test_compose.py
@@ -133,6 +133,15 @@ class Build(unittest.TestCase):
         code, summary = compose.apply(C235_HD, CATALOG, self.dir, factory=True)
         self.assertEqual(code, compose.EXIT_APPLIED)
 
+    def test_deleted_printer_cfg_is_regenerated_even_with_same_boards(self):
+        code, summary = compose.apply(C235, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+        (self.dir / "printer.cfg").unlink()
+        code, summary = compose.apply(C235, CATALOG, self.dir)
+        self.assertEqual(code, compose.EXIT_APPLIED)
+        self.assertTrue(summary["written"])
+        self.assertIn("[mcu]\nserial: /dev/ttyS1", (self.dir / "printer.cfg").read_text())
+
     def test_fingerprint_ignores_cameras(self):
         a = dict(C235, cameras=[])
         b = dict(C235, cameras=[{"name": "cam"}])

--- a/generator/yumi-autoconfig.service
+++ b/generator/yumi-autoconfig.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=YumiOS - detect the boards and install the matching printer.cfg
+# Runs once per boot, before Klipper opens the serial ports. compose.py leaves printer.cfg
+# untouched when the boards have not changed since the last boot (.detected_hardware.json).
+Before=klipper.service
+After=local-fs.target systemd-udev-settle.service
+Wants=systemd-udev-settle.service
+ConditionPathExists=/home/pi/yumi-config/generator/autoconfig.py
+
+[Service]
+Type=oneshot
+User=pi
+Group=pi
+ExecStart=/usr/bin/python3 /home/pi/yumi-config/generator/autoconfig.py --boot
+TimeoutStartSec=300
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/generator/yumi-detect.py
+++ b/generator/yumi-detect.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+yumi-detect — composition materielle d'un pad : cartes MCU + webcams UVC.
+
+Sort un seul JSON normalise {boards, cameras} : c'est le socle commun du generateur
+(printer.cfg depuis boards, config camera/udev depuis cameras), orchestre par yumi-sync.
+
+- Cartes  : delegue a yumi-scan.py --json (scan serie direct). Klippy doit etre ARRETE
+            (il occupe les ports serie). Tourne avec n'importe quel python (yumi-scan
+            se relance tout seul avec klippy-env).
+- Webcams : detection v4l2 directe, A CHAUD (sans toucher a Klipper). Cible les vrais
+            peripheriques de CAPTURE USB UVC (via /dev/v4l/by-id/*-index0 + capacite
+            "Video Capture") -> ignore le VPU (video0/cedrus) et les noeuds metadonnees.
+
+Usage :
+    yumi-detect.py [--no-boards] [PORT ...]
+"""
+import os
+import sys
+import glob
+import re
+import json
+import argparse
+import subprocess
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# Fichier d'etat runtime du pad, HORS repo (comme monitoring_state.json /
+# .yumi_install_state.json de yumi_sync) -> n'introduit jamais de "git dirty".
+DEFAULT_OUT = os.path.expanduser('~/.yumi_composition.json')
+
+
+def scan_boards(ports=None):
+    """Lit les cartes via yumi-scan.py --json et normalise le descripteur en champs."""
+    cmd = [sys.executable, os.path.join(HERE, 'yumi-scan.py'), '--json']
+    if ports:
+        cmd += ports
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        raw = json.loads(p.stdout)
+    except Exception as e:
+        return [{'error': 'yumi-scan KO: %r' % e}]
+    boards = []
+    for r in raw:
+        cfg = r.get('YUMI_CONFIG')
+        if not cfg:
+            continue
+        d = dict(kv.split('=', 1) for kv in cfg.split(';') if '=' in kv)
+        # axes drivers (x/y/z/e0..) et moteurs (mx/my/mz) deja dans d
+        drivers = {k: v for k, v in d.items()
+                   if k in ('x', 'y', 'z') or re.fullmatch(r'e\d+', k)}
+        motors = {k[1:]: v for k, v in d.items() if re.fullmatch(r'm[xyz]', k)}
+        # ensemble piezo Z-tap grave: piezo=element ; pzb=carte ; pzbv=version carte
+        piezo = None
+        if d.get('piezo') or d.get('pzb'):
+            piezo = {'element': d.get('piezo'),
+                     'board': d.get('pzb'),
+                     'board_version': d.get('pzbv')}
+        boards.append({
+            'port': r.get('port'),
+            'uid': d.get('uid'),
+            'board': d.get('board'),
+            'cpu': d.get('cpu'),
+            'device': d.get('device'),
+            'conn': d.get('conn'),
+            'lot': d.get('lot'),
+            'drivers': drivers,
+            'motors': motors,
+            'piezo': piezo,
+            'comment': r.get('YUMI_COMMENT') or None,
+            'klipper': r.get('version'),
+            'descriptor': cfg,
+        })
+    return boards
+
+
+def _v4l2(dev, *args):
+    try:
+        return subprocess.run(['v4l2-ctl', '-d', dev, *args],
+                              capture_output=True, text=True, timeout=8).stdout
+    except Exception:
+        return ''
+
+
+def scan_cameras():
+    """Vraies webcams = peripheriques de CAPTURE USB UVC (by-id *-index0 + 'Video Capture')."""
+    cams, seen = [], set()
+    for byid in sorted(glob.glob('/dev/v4l/by-id/*-index0')):
+        real = os.path.realpath(byid)
+        if real in seen:
+            continue
+        info = _v4l2(real, '--all')
+        if 'Video Capture' not in info:      # exclut VPU / noeuds non-capture
+            continue
+        seen.add(real)
+        m = re.search(r'Card type\s*:\s*(.+)', info)
+        name = m.group(1).strip() if m else os.path.basename(byid)
+        res = sorted(set(re.findall(r'Size: Discrete (\d+x\d+)',
+                                    _v4l2(real, '--list-formats-ext'))),
+                     key=lambda s: int(s.split('x')[0]) * int(s.split('x')[1]))
+        # symlink udev yumi eventuel pointant sur ce device
+        webcam_link = next((l for l in glob.glob('/dev/webcam*')
+                            if os.path.realpath(l) == real), None)
+        cams.append({
+            'name': name,
+            'by_id': os.path.basename(byid),
+            'capture': real,
+            'webcam_symlink': webcam_link,
+            'resolutions': res,
+        })
+    return cams
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Composition materielle du pad (boards + cameras)")
+    ap.add_argument('--no-boards', action='store_true',
+                    help="cameras seules (ne touche pas a klippy)")
+    ap.add_argument('ports', nargs='*', help="ports cartes (defaut: auto-detection)")
+    ap.add_argument('--out', default=DEFAULT_OUT,
+                    help="fichier JSON de composition (defaut: ~/.yumi_composition.json, hors repo ; '-' = stdout)")
+    a = ap.parse_args()
+    out = {
+        'boards': [] if a.no_boards else scan_boards(a.ports or None),
+        'cameras': scan_cameras(),
+    }
+    js = json.dumps(out, ensure_ascii=False, indent=2)
+    if a.out == '-':
+        print(js)
+    else:
+        # ecriture atomique : le generateur lit toujours un JSON complet
+        tmp = a.out + '.tmp'
+        with open(tmp, 'w', encoding='utf-8') as f:
+            f.write(js + '\n')
+        os.replace(tmp, a.out)
+        print("composition -> %s  (%d cartes, %d cameras)"
+              % (a.out, len(out['boards']), len(out['cameras'])))
+
+
+if __name__ == '__main__':
+    main()

--- a/generator/yumi-scan.py
+++ b/generator/yumi-scan.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+yumi-scan — lit l'identite YUMI (YUMI_CONFIG / YUMI_COMMENT) de chaque carte MCU
+connectee, EN DIRECT sur le port serie, SANS que Klipper soit demarre.
+
+Pourquoi : la macro console `DEVICE` n'existe que si klippy tourne ET est connecte.
+Pour le QC usine et le SAV (carte vierge de config, printer.cfg casse, klippy en erreur),
+on doit pouvoir interroger la carte quand meme. Ce script parle directement au MCU avec
+le protocole Klipper (recupere le data dictionary, qui contient les constantes gravees).
+
+Tourne SUR LE PAD (host NanoPi/Pi), pas sur le VPS. Reutilise les libs de ~/klipper/klippy.
+
+IMPORTANT : Klipper doit etre ARRETE (il occupe les ports serie) :
+    sudo systemctl stop klipper
+    ./yumi-scan.py
+    sudo systemctl start klipper
+
+Usage :
+    yumi-scan.py [PORT ...] [-b 250000] [--json]
+Sans PORT : auto-detection depuis printer.cfg ([mcu] serial:) + /dev/serial/by-id/*.
+"""
+import os
+import sys
+import glob
+import re
+import json
+import argparse
+import subprocess
+
+
+def ensure_klippy_python():
+    """Les libs Klipper (reactor->greenlet) ne sont que dans le venv klippy-env.
+    Si on tourne avec un python qui n'a pas greenlet, on se relance avec celui du venv."""
+    try:
+        import greenlet  # noqa: F401
+        return
+    except ImportError:
+        pass
+    # NB: comparer les chemins BRUTS (pas realpath) : le python du venv est souvent un
+    # symlink vers le python systeme, mais ses site-packages (greenlet) sont differents.
+    for venv in (os.path.expanduser('~/klippy-env/bin/python'),
+                 '/home/pi/klippy-env/bin/python'):
+        if os.path.isfile(venv) and os.path.abspath(venv) != os.path.abspath(sys.executable):
+            os.execv(venv, [venv] + sys.argv)
+    sys.exit("ERREUR: 'greenlet' absent et klippy-env introuvable (lancer avec ~/klippy-env/bin/python).")
+
+
+def find_klippy():
+    for d in (os.path.expanduser('~/klipper/klippy'),
+              '/home/pi/klipper/klippy', '/opt/klipper/klippy'):
+        if os.path.isfile(os.path.join(d, 'serialhdl.py')):
+            return d
+    sys.exit("ERREUR: Klipper introuvable (klippy/serialhdl.py).")
+
+
+def detect_ports():
+    ports = []
+    # 1. serials declares dans la config Klipper
+    for cfg in glob.glob(os.path.expanduser('~/printer_data/config/*.cfg')):
+        try:
+            txt = open(cfg, encoding='utf-8', errors='ignore').read()
+        except OSError:
+            continue
+        for m in re.finditer(r'(?m)^\s*serial\s*:\s*(\S+)', txt):
+            ports.append(m.group(1))
+    # 2. tous les peripheriques serie USB (cartes non encore dans la config incluses)
+    ports += sorted(glob.glob('/dev/serial/by-id/*'))
+    ports += sorted(glob.glob('/dev/ttyACM*'))
+    ports += sorted(glob.glob('/dev/ttyUSB*'))
+    # uniques par device REEL (realpath) -> evite le doublon /dev/serial/by-id <-> /dev/ttyACMx
+    seen, out = set(), []
+    for p in ports:
+        if 'klipper_host_mcu' in p or p.startswith('/tmp/'):
+            continue
+        rp = os.path.realpath(p)
+        if rp in seen:
+            continue
+        seen.add(rp)
+        out.append(p)
+    return out
+
+
+def read_port(port, baud, timeout=8.):
+    """Lit un port (UN seul) — execute dans son propre process pour un etat reactor propre."""
+    sys.path.insert(0, find_klippy())
+    import reactor as kreactor
+    import serialhdl
+    r = kreactor.Reactor()
+    ser = serialhdl.SerialReader(r)
+    out = {'port': port}
+
+    def cb(eventtime):
+        try:
+            ser.connect_uart(port, baud)
+            mp = ser.get_msgparser()
+            c = mp.get_constants()
+            out['version'] = mp.get_version_info()[0]
+            out['YUMI_CONFIG'] = c.get('YUMI_CONFIG')
+            out['YUMI_COMMENT'] = c.get('YUMI_COMMENT')
+        except Exception as e:
+            out['error'] = repr(e)
+        r.end()
+        return r.NEVER
+
+    def watchdog(eventtime):
+        if 'YUMI_CONFIG' not in out and 'error' not in out:
+            out['error'] = 'timeout (pas de reponse Klipper sur ce port)'
+        r.end()
+        return r.NEVER
+
+    r.register_callback(cb)
+    r.register_timer(watchdog, r.monotonic() + timeout)
+    try:
+        r.run()
+    finally:
+        try:
+            ser.disconnect()
+        except Exception:
+            pass
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Scan des cartes MCU Yumi (hors klippy)")
+    ap.add_argument('ports', nargs='*', help="ports serie (defaut: auto-detection)")
+    ap.add_argument('-b', '--baud', type=int, default=250000)
+    ap.add_argument('--json', action='store_true', help="sortie JSON")
+    ap.add_argument('--single', help=argparse.SUPPRESS)  # mode interne: 1 port = 1 process
+    args = ap.parse_args()
+
+    ensure_klippy_python()   # se relance avec le python de klippy-env si besoin
+
+    # Mode interne : on lit exactement un port et on rend du JSON sur stdout.
+    if args.single:
+        print(json.dumps(read_port(args.single, args.baud), ensure_ascii=False))
+        return
+
+    ports = args.ports or detect_ports()
+    if not ports:
+        sys.exit("Aucun port a scanner (passe-les en argument ou demarre depuis le pad).")
+
+    # Un sous-process par port -> etat reactor/serie propre a chaque fois.
+    results = []
+    for p in ports:
+        try:
+            proc = subprocess.run(
+                [sys.executable, os.path.abspath(__file__), '--single', p, '-b', str(args.baud)],
+                capture_output=True, text=True, timeout=20)
+            results.append(json.loads(proc.stdout.strip().splitlines()[-1]))
+        except Exception as e:
+            results.append({'port': p, 'error': 'scan KO: %r %s' % (e, proc.stderr[-200:] if 'proc' in dir() else '')})
+
+    if args.json:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+        return
+
+    found = 0
+    for res in results:
+        print("\n=== %s ===" % res['port'])
+        if res.get('YUMI_CONFIG'):
+            found += 1
+            print("  YUMI_CONFIG : %s" % res['YUMI_CONFIG'])
+            if res.get('YUMI_COMMENT'):
+                print("  YUMI_COMMENT: %s" % res['YUMI_COMMENT'])
+            print("  Klipper     : %s" % res.get('version', '?'))
+        elif res.get('error'):
+            print("  (non lu) %s" % res['error'])
+        else:
+            print("  (carte sans constante YUMI — firmware non-Yumi ?)")
+    print("\n%d carte(s) Yumi identifiee(s) sur %d port(s)." % (found, len(results)))
+
+
+if __name__ == '__main__':
+    main()

--- a/install.sh
+++ b/install.sh
@@ -500,6 +500,16 @@ if run_privileged cp "$PROJECT_DIR/yumi-usb-update.service" /etc/systemd/system/
 else
     echo "WARNING: no sudo access, skipping systemd service install"
 fi
+
+# === Hardware detection -> printer.cfg at boot (generator/autoconfig.py, before Klipper) ===
+echo "Installing yumi-autoconfig.service..."
+if run_privileged cp "$PROJECT_DIR/generator/yumi-autoconfig.service" /etc/systemd/system/yumi-autoconfig.service; then
+    run_privileged systemctl daemon-reload
+    run_privileged systemctl enable yumi-autoconfig.service
+    echo "yumi-autoconfig.service enabled at boot (boards scan, printer.cfg only rewritten when they change)"
+else
+    echo "WARNING: could not install yumi-autoconfig.service (no privileges?)"
+fi
 echo "USB offline update service ...[Done]"
 
 # === Fix WiFi USB dongle autosuspend ===


### PR DESCRIPTION
The pad configures itself from the boards plugged in — no product picked by hand, and nothing rewritten while the machine stays the same.

**Where it runs**: `yumi-autoconfig.service` (installed and enabled by `install.sh`, so every pad gets it through YUMI_SYNC), ordered `Before=klipper.service`: one scan per boot while the serial ports are still free, no service stopped or started.

**What it does** (`generator/`):
- `yumi-scan.py` / `yumi-detect.py` (from the firmware builder) read the `YUMI_CONFIG` descriptor of every MCU over serial → composition JSON (`~/.yumi_composition.json`).
- `compose.py`: if the boards (port, uid, device) are the ones recorded in `.detected_hardware.json`, **printer.cfg is left untouched** (hand edits included, exit 4). Otherwise it maps the composition to a catalog product (`device=` → machine, HyperDrive present → CHROMAX X12 + 7 YMS, `.yumi_product_prefs.json` for head type/nozzle, defaults in the catalog's `detection` section), injects the detected ports into `[mcu]`/`[mcu smartbox]` through `generator.generate(product, overrides)`, and applies the policy: same main board → SAVE_CONFIG preserved; different board → factory; no main board → alert, nothing touched (exit 2); no matching product → minimal cfg so Klipper still connects (exit 3).
- `autoconfig.py`: orchestration (`--boot` at boot; run by hand it stops/starts Klipper through Moonraker's API, no sudo).
- Rules live in the catalog, not in code. 17 unit tests (stdlib). README section.
- Generator fix found by the first real run: `[yumi_z_tap]` no longer gets `pressure_switch_x/y` in mesh-zero mode (Klipper refused the config).

**Verified on the bench**: C235 Smart Maker on `/dev/ttyS1` (uid BBA413) → `C235_DD_LW_04` written → Klipper **ready**, MCU stm32f401xc, `YUMI_CONFIG` read; second run with the same board → `unchanged`, cfg untouched.

Next (not in this PR): point KlipperScreen `cfg_wizard.py` at this pipeline (it calls a `scanner.py` that does not exist); catalog products for a second HyperDrive (USB, E7–E11).