### PR TITLE
qc: route the mains voltage into the M3 nameplate

### DIFF
--- a/qc/m3-plaque/print_plaque.py
+++ b/qc/m3-plaque/print_plaque.py
@@ -3,8 +3,9 @@
 print_plaque.py — Imprime la plaque signalétique de l'imprimante 3D sur la M3, DEPUIS LE PAD.
 
 Lit l'identité machine via Moonraker (localhost:7125) : UID STM32 (série) + YUMI_CONFIG
-(modèle=device, tension=mains, lot), rend la plaque (render_plaque, Pillow), puis l'envoie
-à la M3 (/dev/ttyACM*, driver niim_print). Conçu pour être lancé par la macro QC_PRINT_PLAQUE.
+(modèle=device, tension secteur=mains, puissance plateau=bedw, lot), rend la plaque
+(render_plaque, Pillow), puis l'envoie à la M3 (/dev/ttyACM*, driver niim_print).
+Conçu pour être lancé par la macro QC_PRINT_PLAQUE.
 
 ⚠️ Copie VENDORISÉE du dossier m3-driver/ du repo YUMI-POS-Printer (source de dev = pad
 192.168.100.113). install.sh la déploie vers ~/yumi-m3-plaque/ (chemin appelé par la macro
@@ -13,18 +14,112 @@ réellement sur les pads d'usine, via YUMI_SYNC. Les deux copies se modifient EN
 
 Usage (pad) :
   python3 print_plaque.py                         # auto : lit tout via Moonraker
-  python3 print_plaque.py --serial <UID> --model C235 --voltage "220V ~ 50/60Hz"
+  python3 print_plaque.py --serial <UID> --model C235 --mains 110V --power 420   # tout forcé (sans Moonraker)
   python3 print_plaque.py --dry-run --out /tmp/plaque.png   # rend sans imprimer
-Options : --moonraker URL, --port, --density 3, --qty 1, --orient none|180|mirror, --offx -1, --offy -0.2, --power "350 W"
+Options : --moonraker URL, --port, --density 3, --qty 1, --orient none|180|mirror, --offx -1, --offy -0.2,
+          --mains 220V|110V (tension gravée, sinon lue au MCU), --voltage "libellé" (texte imprimé, sinon
+          déduit de la tension), --power 420 (W total, sinon bedw gravé + PSU), --no-gate (réimpression)
+
+Codes de sortie : 0 imprimé · 3 machine pas PASS sur qc.yumi-lab.com · 4 identité électrique
+incomplète (tension/puissance inconnues) ou gabarit qui ne route pas la tension de la machine.
+Dans les deux cas RIEN n'est imprimé : une plaque fausse est pire qu'une plaque absente.
 """
-import os, sys, json, time, argparse, urllib.request, urllib.parse, urllib.error
+import os, sys, re, json, math, time, argparse, urllib.request, urllib.parse, urllib.error
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import render_plaque
+
+# ── Tension secteur gravée → libellé imprimé + tension de calcul du courant ──────────────
+# La tension secteur est CHOISIE au build du firmware (firmware.yumi-lab.com, catalog.json
+# `mains_voltages` = 220V | 110V) et gravée dans YUMI_CONFIG (`mains=110V`). Le libellé imprimé
+# est la plage nominale correspondante ; le courant nominal est calculé à la borne BASSE de la
+# plage (courant le plus élevé) et arrondi au 1 A SUPÉRIEUR (sécurité). SEULE table à toucher
+# pour changer un libellé ou une borne : le gabarit (label.yumi-lab.com) ne porte que {voltage}.
+# Cas vécu (12/09/2026) : gabarit avec « 220–240 V~ » codé en dur + courant divisé par 220 en
+# dur -> toutes les machines 110 V sortaient avec une plaque 220 V et un courant moitié trop bas.
+# Consigne Nicolas (12/09/2026) : le rendu 220 V reste STRICTEMENT identique à la plaque d'avant
+# (« 220–240 V~ », P/220) ; seul le 110 V change. Plage 110 V et tension de calcul (vmin) = convention
+# à confirmer par Nicolas (100–120 V~ et P/100 ici ; à 120 V nominal le C235 ferait 4 A au lieu de 5).
+MAINS_RATINGS = {
+    '220V': {'voltage': '220–240 V~', 'vmin': 220},
+    '110V': {'voltage': '100–120 V~', 'vmin': 100},
+}
+PSU_WATTS = 120  # alim DC fixe C-SERIES (W), ajoutée à la puissance plateau gravée (bedw)
+
+# Contrat avec le panel QC (qc_engine.plaque_feedback lit ces deux chaînes dans la console).
+REFUSED = 'QC:PLAQUE:REFUS'
+PRINTED = 'Plaque imprimée'
+
+def norm_mains(v):
+    """'110', '110v', ' 110V ' -> '110V' ; '' si vide (même règle que qc.yumi-lab.com)."""
+    v = (v or '').strip().upper()
+    if v and v[-1].isdigit():
+        v += 'V'
+    return v
+
+def mains_rating(mains):
+    """{'voltage': libellé, 'vmin': V de calcul} pour une tension gravée ; None si inconnue."""
+    return MAINS_RATINGS.get(norm_mains(mains))
+
+def rated_amps(total_watts, vmin):
+    """Courant nominal (A) = P / borne basse de la plage, arrondi au 1 A supérieur."""
+    return int(math.ceil(float(total_watts) / float(vmin)))
+
+def parse_yumi_config(message):
+    """Ligne DEVICE du gcode_store ('// [mcu] board=X;device=C235;mains=110V;bedw=300;…')
+    -> (dict clé=valeur, ligne nettoyée sans préfixe '// [mcu] ')."""
+    clean = str(message).strip().lstrip('/').strip()
+    clean = re.sub(r'^\[[^\]]*\]\s*', '', clean).strip()
+    kv = dict(p.split('=', 1) for p in clean.split(';') if '=' in p)
+    return {k.strip(): v.strip() for k, v in kv.items()}, clean
+
+_DASHES = re.compile(r'[‐-―−-]')
+_MAINS_TXT = re.compile(r'\d\s*V\s*~|\d\s*V\s*AC\b|\d+\s*-\s*\d+\s*V\b', re.I)
+
+def _norm_txt(s):
+    return re.sub(r'\s+', ' ', _DASHES.sub('-', str(s))).strip().upper()
+
+def voltage_routing_error(template, voltage):
+    """Le gabarit doit ROUTER la tension de la machine : via {voltage}, ou en portant
+    exactement son libellé. Une ligne d'entrée secteur codée en dur pour une AUTRE tension
+    (le bug du 12/09/2026 : gabarit 220–240 V~ sur une machine 110 V) -> message, sinon None."""
+    if voltage in (None, '', '?'):
+        return 'tension inconnue : rien à router sur la plaque'
+    want = _norm_txt(voltage)
+    for e in template.get('elements', []):
+        if e.get('t') not in ('text', 'serial'):
+            continue
+        c = str(e.get('c', ''))
+        if '{voltage}' in c:
+            continue
+        if _MAINS_TXT.search(_norm_txt(c)) and want not in _norm_txt(c):
+            return ('le gabarit code la tension en dur (« %s ») au lieu de {voltage} -- machine %s'
+                    % (c, voltage))
+    return None
 
 def _mr(url, path, method='GET', timeout=6):
     req = urllib.request.Request(url.rstrip('/') + path, method=method)
     with urllib.request.urlopen(req, timeout=timeout) as r:
         return json.load(r)
+
+def identity_from_store(store):
+    """Extrait l'identité (serial, model, mains, bedw, lot, yumi_config) d'un gcode_store."""
+    ident = {}
+    yc = ''
+    for e in store:
+        m = e.get('message', '')
+        if 'MCU_UID=' in m:
+            ident['serial'] = m.split('MCU_UID=', 1)[1].strip()
+        if 'device=' in m.lower():
+            yc = m
+    if yc:
+        kv, clean = parse_yumi_config(yc)
+        ident['yumi_config'] = clean
+        for k in ('device', 'mains', 'bedw', 'lot'):
+            if kv.get(k):
+                ident['model' if k == 'device' else k] = kv[k]
+        if not ident.get('serial') and kv.get('uid'):
+            ident['serial'] = kv['uid']  # repli (hash, non unique)
+    return ident
 
 def moonraker_identity(url, salves=2, polls=8, poll_interval=0.4, store_count=150, send_timeout=1.5):
     """Exécute DEVICE + QUERY_MCU_UID (si pas déjà fait par l'appelant) puis POLL le
@@ -60,28 +155,12 @@ def moonraker_identity(url, salves=2, polls=8, poll_interval=0.4, store_count=15
             except Exception as e:
                 print('WARN Moonraker gcode_store:', e, file=sys.stderr)
                 continue
-            yc = ''
-            for e in store:
-                m = e.get('message', '')
-                if 'MCU_UID=' in m:
-                    ident['serial'] = m.split('MCU_UID=', 1)[1].strip()
-                if 'device=' in m.lower():
-                    yc = m
-            if yc:
-                import re
-                clean = re.sub(r'^\s*\[[^\]]*\]\s*', '', yc).strip()  # retire "// [mcu] " etc.
-                clean = clean.lstrip('/ ').strip()
-                kv = dict(p.split('=', 1) for p in clean.split(';') if '=' in p)
-                ident['yumi_config'] = clean
-                if kv.get('device'): ident['model'] = kv['device']
-                if kv.get('mains'): ident['voltage'] = kv['mains'] + ' ~ 50/60Hz'
-                if kv.get('lot'): ident['lot'] = kv['lot']
-                if kv.get('bedw'): ident['bedw'] = kv['bedw']  # puissance plateau (W)
-                if not ident.get('serial') and kv.get('uid'): ident['serial'] = kv['uid']  # repli (hash, non unique)
-            if ident.get('serial') and ident.get('model') and ident.get('bedw'):
+            ident = identity_from_store(store) or ident
+            if all(ident.get(k) for k in ('serial', 'model', 'mains', 'bedw')):
                 return ident
-        print('WARN: identite incomplete apres salve %d/%d (serial=%r model=%r bedw=%r)'
-              % (attempt, salves, ident.get('serial'), ident.get('model'), ident.get('bedw')), file=sys.stderr)
+        print('WARN: identite incomplete apres salve %d/%d (serial=%r model=%r mains=%r bedw=%r)'
+              % (attempt, salves, ident.get('serial'), ident.get('model'), ident.get('mains'),
+                 ident.get('bedw')), file=sys.stderr)
     return ident
 
 def yumi_id():
@@ -123,12 +202,42 @@ def image_to_rows(img, threshold=128):
         rows.append(row)
     return rows, W, H
 
+def electrical_rating(mains, bedw, psu=PSU_WATTS, power=None, voltage=None):
+    """Tension imprimée + puissance + courant d'une machine, ou la liste des raisons de
+    REFUSER l'impression. Pure (testable) : ne touche ni Moonraker ni le gabarit.
+    -> ({'voltage', 'power', 'amps', 'watts'}, [problèmes])"""
+    problems = []
+    rating = mains_rating(mains)
+    if not rating:
+        problems.append('tension secteur inconnue (mains=%r absent de YUMI_CONFIG ou hors table %s) '
+                        '-- reflasher via firmware.yumi-lab.com ou passer --mains'
+                        % (mains, '/'.join(MAINS_RATINGS)))
+    if power and re.search(r'\d+', str(power)):                  # override manuel --power
+        watts = int(re.search(r'\d+', str(power)).group())
+    elif bedw and str(bedw).strip().isdigit():
+        watts = int(bedw) + psu                                  # bed gravé (par machine) + PSU DC fixe
+    else:
+        watts = 0
+        problems.append('puissance plateau inconnue (bedw= absent de YUMI_CONFIG) -- courant non '
+                        'calculable, reflasher via firmware.yumi-lab.com ou passer --power')
+    amps = rated_amps(watts, rating['vmin']) if (watts and rating) else 0
+    out = {
+        'voltage': voltage or (rating['voltage'] if rating else '?'),
+        'power': ('%d W' % watts) if watts else '',
+        'amps': ('%.1f' % amps) if amps else '?',
+        'watts': watts,
+    }
+    return out, problems
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--moonraker', default='http://127.0.0.1:7125')
-    ap.add_argument('--serial'); ap.add_argument('--model'); ap.add_argument('--voltage')
-    ap.add_argument('--power', default=None, help='sinon calculé = plateau(bedw MCU) + PSU')
-    ap.add_argument('--psu', type=int, default=120, help='puissance alim DC fixe C-SERIES (W)')
+    ap.add_argument('--serial'); ap.add_argument('--model')
+    ap.add_argument('--mains', help='tension secteur gravée (%s) ; sinon lue au MCU (YUMI_CONFIG mains=)'
+                    % '|'.join(MAINS_RATINGS))
+    ap.add_argument('--voltage', help='libellé imprimé ; sinon déduit de la tension (ex. « 220–240 V~ »)')
+    ap.add_argument('--power', default=None, help='puissance totale (W) ; sinon plateau (bedw MCU) + PSU')
+    ap.add_argument('--psu', type=int, default=PSU_WATTS, help='puissance alim DC fixe C-SERIES (W)')
     ap.add_argument('--lot'); ap.add_argument('--qr')
     ap.add_argument('--qr-base', dest='qr_base', default='https://qc.yumi-lab.com/report/',
                     help='le QR encode <qr_base><machine_uid> (page rapport QC)')
@@ -145,8 +254,10 @@ def main():
     a = ap.parse_args()
 
     # MACHINE UID = UID STM32 (24 hex) lu via QUERY_MCU_UID (Moonraker, nécessite [mcu_uid]).
-    # modèle/tension/lot = YUMI_CONFIG (DEVICE). Série = MACHINE UID. QR = page rapport QC.
-    ident = moonraker_identity(a.moonraker)
+    # modèle/tension/puissance/lot = YUMI_CONFIG (DEVICE). Série = MACHINE UID. QR = page rapport QC.
+    # Tout forcé en ligne de commande -> pas de Moonraker (test hors pad, réimpression manuelle).
+    forced = all((a.serial, a.model, a.mains, a.power))
+    ident = {} if forced else moonraker_identity(a.moonraker)
     uid = (a.serial or ident.get('serial') or '').strip().upper()
     if not uid:
         uid = yumi_id()  # REPLI : MAC end0 (≠ UID STM32) si [mcu_uid] non chargé
@@ -159,32 +270,22 @@ def main():
         if st != 'PASS':
             why = {'ABSENT': 'aucun QC PASSED sur qc.yumi-lab.com pour cette machine',
                    'UNREACHABLE': 'qc.yumi-lab.com injoignable (reseau ?)'}.get(st, 'QC=' + st)
-            print('QC:PLAQUE:REFUS uid=%s -- %s' % (uid, why))
+            print('%s uid=%s -- %s' % (REFUSED, uid, why))
             sys.exit(3)
         print('QC:PLAQUE:GATE_OK PASSED uid=%s' % uid)
 
-    # CALCUL AUTO PAR IMPRIMANTE (zéro saisie, AUCUNE table codée en dur) : la puissance du BED
-    # est LUE SUR CHAQUE machine via Moonraker DEVICE (champ `bedw` du YUMI_CONFIG gravé au MCU).
-    # Puissance MAX = bedw + PSU DC fixe (120 W, C-SERIES). Courant nominal = P / 220 V (tension
-    # mini de la plage), arrondi au 1 A SUPÉRIEUR (sécurité).
-    #   -> le 350 W du C235 vient du FIRMWARE (bedw=350), pas du script : 350 + 120 = 470 W ->
-    #      470 / 220 = 2,14 A -> ceil -> 3,0 A. (Une machine à bedw=300 donnerait 2,0 A.)
-    import math, re
+    # CALCUL AUTO PAR IMPRIMANTE (zéro saisie, AUCUNE table par modèle) : tension secteur (mains)
+    # et puissance du BED (bedw) sont LUES SUR CHAQUE machine via DEVICE (YUMI_CONFIG gravé au
+    # MCU). Puissance MAX = bedw + PSU DC fixe (120 W, C-SERIES). Courant = P / borne basse de la
+    # plage de la tension gravée (MAINS_RATINGS), arrondi au 1 A SUPÉRIEUR.
+    #   C235 220 V : 300 + 120 = 420 W -> 420 / 220 = 1,9 -> 2 A.   C235 110 V : 420 / 100 -> 5 A.
     model = a.model or ident.get('model') or '?'
-    bedw = ident.get('bedw')
-    if a.power and re.search(r'\d+', a.power):            # override manuel éventuel --power
-        pw = int(re.search(r'\d+', a.power).group())
-    elif bedw and str(bedw).strip().isdigit():
-        pw = int(bedw) + a.psu                            # bed (MCU, par machine) + PSU DC fixe
-    else:
-        pw = 0
-        print('WARN: puissance bed (bedw) absente de DEVICE -> courant non calculé', file=sys.stderr)
-    amps = math.ceil(pw / 220.0) if pw else 0
+    elec, problems = electrical_rating(a.mains or ident.get('mains'), ident.get('bedw'),
+                                       psu=a.psu, power=a.power, voltage=a.voltage)
     data = {
         'serial': uid,
         'model': model,
-        'voltage': a.voltage or ident.get('voltage') or '220–240 V~',
-        'power': ('%d W' % pw) if pw else '', 'amps': ('%.1f' % amps) if amps else '?',
+        'voltage': elec['voltage'], 'power': elec['power'], 'amps': elec['amps'],
         'lot': a.lot or ident.get('lot') or '',
         'origin': a.origin, 'maker': a.maker,
         'qr': a.qr or (a.qr_base + uid),
@@ -193,6 +294,17 @@ def main():
     print('Identité plaque :', json.dumps(data, ensure_ascii=False))
     tpl = render_plaque.load_template(a.template)
     print('Template :', a.template if tpl else '(défaut embarqué — fetch échoué/absent)')
+    # GUARD routage : le gabarit doit porter {voltage} (ou exactement la tension de CETTE machine).
+    err = voltage_routing_error(tpl or render_plaque.DEFAULT_TEMPLATE, data['voltage'])
+    if err:
+        problems.append(err)
+    if problems:
+        for p in problems:
+            print('%s uid=%s -- %s' % (REFUSED, uid, p))
+        if not a.dry_run:
+            sys.exit(4)
+        print('DRY-RUN : rendu quand même pour contrôle (une impression réelle serait refusée)',
+              file=sys.stderr)
     img = render_plaque.render(data, tpl)
     # décalage de calage (offset mm) : translate le contenu sur fond noir
     if a.offx or a.offy:
@@ -211,7 +323,7 @@ def main():
     try:
         print('Impression sur', m.path, '…')
         m.print_image(rows, W, Hh, density=a.density, quantity=max(1, a.qty), count_mode='auto')
-        print('✅ Plaque imprimée.')
+        print('✅ %s.' % PRINTED)
     finally:
         m.close()
 

--- a/qc/m3-plaque/render_plaque.py
+++ b/qc/m3-plaque/render_plaque.py
@@ -51,7 +51,8 @@ def default_template():
         {'t': 'text', 'c': 'Model: {model}', 'x': 4, 'y': 40.5, 'sz': 3.6},
         {'t': 'serial', 'c': 'S/N: {serial}', 'x': 4, 'y': 46, 'sz': 3.2, 'fitw': 47, 'mono': True},
         {'t': 'qr', 'c': '{qr}', 'x': 53, 'y': 39, 'sz': 17},
-        {'t': 'text', 'c': 'Input: 220–240 V~, 50/60 Hz, {amps} A', 'x': 4, 'y': 58, 'sz': 2.9, 'weight': 'normal'},
+        # {voltage} vient de la tension gravée au MCU (print_plaque.MAINS_RATINGS) : jamais codée en dur ici.
+        {'t': 'text', 'c': 'Rated Input: {voltage}, 50/60 Hz, {amps} A', 'x': 4, 'y': 58, 'sz': 2.9, 'weight': 'normal'},
         {'t': 'text', 'c': 'Made in China', 'x': 4, 'y': 62.5, 'sz': 3.2},
         {'t': 'line', 'x': 4, 'y': 67, 'w': 67, 'thick': 0.3},
     ]

--- a/qc/qc_engine.py
+++ b/qc/qc_engine.py
@@ -244,6 +244,25 @@ QC_TESTS_YMS12 = [
 ]
 
 
+# Retour de QC_PRINT_PLAQUE (print_plaque.py lancé par RUN_SHELL_COMMAND verbose, hors venv :
+# les deux chaînes sont le CONTRAT entre les deux process, print_plaque.py les émet) à montrer à
+# l'opérateur : le pad REFUSE une plaque fausse (QC pas PASS, tension/puissance absentes du
+# firmware, gabarit qui code une autre tension en dur -- bug 110 V du 12/09/2026). Sans popup le
+# seul symptôme serait « rien ne sort ». -> (niveau popup KlipperScreen 1=info/3=erreur, texte).
+PLAQUE_REFUSED = "QC:PLAQUE:REFUS"
+PLAQUE_PRINTED = "Plaque imprimée"
+
+
+def plaque_feedback(msg):
+    text = str(msg or "")
+    if PLAQUE_REFUSED in text:
+        reason = text.split("--", 1)[1].strip() if "--" in text else text.strip()
+        return 3, "标签未打印 / Plaque refusée : " + reason
+    if PLAQUE_PRINTED in text:
+        return 1, "标签已打印 / Plaque imprimée"
+    return None
+
+
 def tests_for_model(model):
     """Séquence de tests pour le modèle choisi au panel : banc YMS (YMS12)
     ou protocole machine C-series (défaut)."""

--- a/qc/qc_wizard.py
+++ b/qc/qc_wizard.py
@@ -78,7 +78,7 @@ YMS_BENCH_SLOTS = (["main:E0", "main:E1"]
 
 # Import QC engine from ks_includes (symlinked there by install.sh)
 try:
-    from ks_includes.qc_engine import QCEngine, QCState, QCResult, QC_TESTS
+    from ks_includes.qc_engine import QCEngine, QCState, QCResult, QC_TESTS, plaque_feedback
     from ks_includes.qc_yms import (
         allocate_yms_codes,
         build_box_report,
@@ -106,7 +106,7 @@ except ImportError:
     import sys
     import os
     sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
-    from qc_engine import QCEngine, QCState, QCResult, QC_TESTS
+    from qc_engine import QCEngine, QCState, QCResult, QC_TESTS, plaque_feedback
     from qc_yms import (
         allocate_yms_codes,
         build_box_report,
@@ -1911,13 +1911,19 @@ class Panel(ScreenPanel):
     def process_update(self, action, data):
         """Process printer state updates from KlipperScreen."""
         if action == "notify_gcode_response":
-            if isinstance(data, str):
-                self.engine.process_gcode_response(data)
-            elif isinstance(data, list):
-                for msg in data:
-                    if isinstance(msg, str):
-                        self.engine.process_gcode_response(msg)
+            msgs = [data] if isinstance(data, str) else (data if isinstance(data, list) else [])
+            for msg in msgs:
+                if isinstance(msg, str):
+                    self.engine.process_gcode_response(msg)
+                    self._on_plaque_feedback(msg)
         return False
+
+    def _on_plaque_feedback(self, msg):
+        """Refus ou succès de QC_PRINT_PLAQUE -> popup, en direct seulement (pas au
+        rejeu du gcode_store par _replay_response : un vieux refus n'est pas une news)."""
+        fb = plaque_feedback(msg)
+        if fb:
+            self._screen.show_popup_message(fb[1], level=fb[0])
 
     # ─── HELPERS ───────────────────────────────────────────────
 

--- a/qc/tests/test_m3_plaque.py
+++ b/qc/tests/test_m3_plaque.py
@@ -1,0 +1,167 @@
+"""Plaque signalétique M3 : la tension et le courant imprimés doivent suivre la tension
+secteur gravée au MCU (mains=) ; le rendu 220 V reste identique à la plaque d'avant (Nicolas, 12/09) -- bug du 12/09/2026 : gabarit « 220–240 V~ » codé en dur
+et courant divisé par 220 en dur, toutes les machines 110 V sortaient avec une plaque 220 V."""
+import os
+import sys
+import json
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "m3-plaque"))
+import print_plaque  # noqa: E402
+import render_plaque  # noqa: E402
+
+DEVICE_LINE = ("// [mcu] board=SMART_MAKER_1_X;cpu=STM32F401;conn=UART;device=C235;"
+               "x=SMART_TMC2209_V2;mains=110V;bedw=300;ssr=SSR10DA;lot=20260618;uid=BBA413")
+
+# Gabarit tel que sauvé sur label.yumi-lab.com AVANT le fix : tension codée en dur.
+LEGACY_TEMPLATE = {"version": 1, "label": {"w_mm": 75, "h_mm": 120}, "elements": [
+    {"t": "text", "x": 4, "y": 42, "sz": 3.5, "c": "Model: {model}"},
+    {"t": "serial", "x": 4, "y": 53, "sz": 3.2, "c": "S/N: {serial}", "mono": True, "fitw": 47},
+    {"t": "text", "x": 4, "y": 58, "sz": 2.9, "c": "Rated Input: 220–240 V~, 50/60 Hz, {amps} A"},
+]}
+ROUTED_TEMPLATE = {"version": 1, "label": {"w_mm": 75, "h_mm": 120}, "elements": [
+    {"t": "text", "x": 4, "y": 42, "sz": 3.5, "c": "Model: {model}"},
+    {"t": "text", "x": 4, "y": 58, "sz": 2.9, "c": "Rated Input: {voltage}, 50/60 Hz, {amps} A"},
+]}
+
+
+class TestMainsRatings(unittest.TestCase):
+    def test_table_covers_the_firmware_catalog(self):
+        # firmware.yumi-lab.com catalog.json mains_voltages = ["220V", "110V"]
+        self.assertEqual(set(print_plaque.MAINS_RATINGS), {"220V", "110V"})
+
+    def test_220v_is_the_european_range(self):
+        r = print_plaque.mains_rating("220V")
+        self.assertEqual(r["voltage"], "220–240 V~")
+        self.assertEqual(r["vmin"], 220)
+
+    def test_110v_is_the_north_american_range(self):
+        r = print_plaque.mains_rating("110V")
+        self.assertEqual(r["voltage"], "100–120 V~")
+        self.assertEqual(r["vmin"], 100)
+
+    def test_norm_mains_accepts_the_qc_counter_variants(self):
+        for raw in ("110", "110v", " 110V ", "110V"):
+            self.assertEqual(print_plaque.norm_mains(raw), "110V")
+        self.assertIsNone(print_plaque.mains_rating(""))
+        self.assertIsNone(print_plaque.mains_rating(None))
+        self.assertIsNone(print_plaque.mains_rating("380V"))
+
+
+class TestRatedAmps(unittest.TestCase):
+    """Courant = (bedw + PSU) / borne basse de la plage, arrondi au 1 A supérieur."""
+
+    def test_c235_220v(self):
+        elec, problems = print_plaque.electrical_rating("220V", "300")
+        self.assertEqual(problems, [])
+        self.assertEqual(elec["watts"], 420)
+        self.assertEqual(elec["amps"], "2.0")
+        self.assertEqual(elec["voltage"], "220–240 V~")
+
+    def test_c235_110v_draws_more_current_than_220v(self):
+        elec, problems = print_plaque.electrical_rating("110V", "300")
+        self.assertEqual(problems, [])
+        self.assertEqual(elec["voltage"], "100–120 V~")
+        self.assertEqual(elec["amps"], "5.0")     # 420 W / 100 V = 4.2 -> 5 A
+
+    def test_c435_uses_the_bed_power_of_its_voltage(self):
+        # catalog : C435 750 W en 220 V, 550 W en 110 V -- bedw gravé par tension
+        self.assertEqual(print_plaque.electrical_rating("220V", "750")[0]["amps"], "4.0")
+        self.assertEqual(print_plaque.electrical_rating("110V", "550")[0]["amps"], "7.0")
+
+    def test_manual_power_override(self):
+        elec, problems = print_plaque.electrical_rating("220V", None, power="470 W")
+        self.assertEqual(problems, [])
+        self.assertEqual(elec["amps"], "3.0")
+
+    def test_unknown_mains_refuses(self):
+        elec, problems = print_plaque.electrical_rating("", "300")
+        self.assertEqual(elec["voltage"], "?")
+        self.assertEqual(elec["amps"], "?")
+        self.assertEqual(len(problems), 1)
+        self.assertIn("tension secteur inconnue", problems[0])
+
+    def test_unknown_bed_power_refuses(self):
+        elec, problems = print_plaque.electrical_rating("110V", None)
+        self.assertEqual(elec["amps"], "?")
+        self.assertEqual(elec["voltage"], "100–120 V~")
+        self.assertEqual(len(problems), 1)
+        self.assertIn("puissance plateau inconnue", problems[0])
+
+    def test_custom_voltage_label_keeps_the_computed_current(self):
+        elec, _ = print_plaque.electrical_rating("110V", "300", voltage="120 V~")
+        self.assertEqual(elec["voltage"], "120 V~")
+        self.assertEqual(elec["amps"], "5.0")
+
+
+class TestDeviceParsing(unittest.TestCase):
+    def test_parse_device_line_strips_the_respond_prefix(self):
+        kv, clean = print_plaque.parse_yumi_config(DEVICE_LINE)
+        self.assertEqual(kv["board"], "SMART_MAKER_1_X")
+        self.assertEqual(kv["device"], "C235")
+        self.assertEqual(kv["mains"], "110V")
+        self.assertEqual(kv["bedw"], "300")
+        self.assertTrue(clean.startswith("board="))
+
+    def test_identity_from_store_carries_mains_and_bedw(self):
+        store = [{"message": "// MCU_UID=2D0046000D51353234323830"}, {"message": DEVICE_LINE}]
+        ident = print_plaque.identity_from_store(store)
+        self.assertEqual(ident["serial"], "2D0046000D51353234323830")
+        self.assertEqual(ident["model"], "C235")
+        self.assertEqual(ident["mains"], "110V")
+        self.assertEqual(ident["bedw"], "300")
+        self.assertEqual(ident["lot"], "20260618")
+
+
+class TestVoltageRouting(unittest.TestCase):
+    def test_legacy_template_refuses_a_110v_machine(self):
+        err = print_plaque.voltage_routing_error(LEGACY_TEMPLATE, "100–120 V~")
+        self.assertIsNotNone(err)
+        self.assertIn("{voltage}", err)
+
+    def test_legacy_template_still_prints_a_220v_machine(self):
+        # transition : le gabarit en dur est juste par coïncidence pour le 220 V
+        self.assertIsNone(print_plaque.voltage_routing_error(LEGACY_TEMPLATE, "220–240 V~"))
+
+    def test_hyphen_vs_en_dash_does_not_matter(self):
+        tpl = {"elements": [{"t": "text", "c": "Input: 220-240 V~, 50/60 Hz, {amps} A"}]}
+        self.assertIsNone(print_plaque.voltage_routing_error(tpl, "220–240 V~"))
+
+    def test_routed_template_accepts_both_voltages(self):
+        for v in ("220–240 V~", "100–120 V~"):
+            self.assertIsNone(print_plaque.voltage_routing_error(ROUTED_TEMPLATE, v))
+
+    def test_unknown_voltage_is_refused_even_with_a_routed_template(self):
+        self.assertIsNotNone(print_plaque.voltage_routing_error(ROUTED_TEMPLATE, "?"))
+
+    def test_embedded_default_template_routes_the_voltage(self):
+        els = render_plaque.DEFAULT_TEMPLATE["elements"]
+        inputs = [e for e in els if "{amps}" in str(e.get("c", ""))]
+        self.assertEqual(len(inputs), 1)
+        self.assertIn("{voltage}", inputs[0]["c"])
+        self.assertIsNone(print_plaque.voltage_routing_error(render_plaque.DEFAULT_TEMPLATE, "100–120 V~"))
+
+    def test_220v_rendering_is_identical_to_the_legacy_template(self):
+        # Consigne Nicolas : le rendu 220 V ne bouge pas d'un pixel, seul le 110 V change.
+        from PIL import ImageChops
+        data = {"serial": "2D0046000D51353234323830", "model": "C235", "voltage": "220\u2013240 V~",
+                "amps": "2.0", "power": "420 W", "lot": "", "origin": "Made in China", "maker": "",
+                "qr": "https://qc.yumi-lab.com/report/X", "qr2": "https://go.yumi-lab.com"}
+        legacy = render_plaque.render(data, LEGACY_TEMPLATE)
+        routed = {"elements": [dict(e) for e in LEGACY_TEMPLATE["elements"]]}
+        routed["elements"][2]["c"] = "Rated Input: {voltage}, 50/60 Hz, {amps} A"
+        self.assertIsNone(ImageChops.difference(legacy, render_plaque.render(data, routed)).getbbox())
+
+    def test_render_substitutes_the_voltage(self):
+        data = {"serial": "X", "model": "C235", "voltage": "100–120 V~", "amps": "5.0",
+                "power": "420 W", "lot": "", "origin": "Made in China", "maker": "",
+                "qr": "https://qc.yumi-lab.com/report/X", "qr2": "https://go.yumi-lab.com"}
+        img = render_plaque.render(data, ROUTED_TEMPLATE)
+        self.assertEqual(img.size, (render_plaque.MM(75), render_plaque.MM(120)))
+        # au moins des pixels blancs dans la bande de la ligne « Rated Input » (y = 58 mm)
+        band = img.crop((0, render_plaque.MM(57), img.width, render_plaque.MM(62)))
+        self.assertGreater(max(band.getdata()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qc/tests/test_m3_plaque.py
+++ b/qc/tests/test_m3_plaque.py
@@ -163,5 +163,35 @@ class TestVoltageRouting(unittest.TestCase):
         self.assertGreater(max(band.getdata()), 0)
 
 
+class TestPlaqueFeedback(unittest.TestCase):
+    """Le refus du pad doit remonter à l'opérateur (popup), pas seulement « rien ne sort »."""
+
+    def test_refusal_becomes_an_error_popup_with_the_reason(self):
+        from qc import qc_engine
+        msg = ("QC:PLAQUE:REFUS uid=X -- le gabarit code la tension en dur (« Rated Input: "
+               "220–240 V~ ») au lieu de {voltage} -- machine 100–120 V~")
+        level, text = qc_engine.plaque_feedback(msg)
+        self.assertEqual(level, 3)
+        self.assertIn("Plaque refusée", text)
+        self.assertIn("{voltage}", text)
+        self.assertNotIn("uid=X", text)
+
+    def test_success_becomes_an_info_popup(self):
+        from qc import qc_engine
+        level, text = qc_engine.plaque_feedback("✅ Plaque imprimée.")
+        self.assertEqual(level, 1)
+        self.assertIn("Plaque imprimée", text)
+
+    def test_other_lines_are_ignored(self):
+        from qc import qc_engine
+        for msg in ("QC:PLAQUE:START", "QC:PLAQUE:DONE", "Identité plaque : {}", "", None):
+            self.assertIsNone(qc_engine.plaque_feedback(msg))
+
+    def test_contract_strings_match_print_plaque(self):
+        from qc import qc_engine
+        self.assertEqual(print_plaque.REFUSED, qc_engine.PLAQUE_REFUSED)
+        self.assertEqual(print_plaque.PRINTED, qc_engine.PLAQUE_PRINTED)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The M3 nameplate (`QC_PRINT_PLAQUE`) printed **220–240 V~** on every machine: the template line on label.yumi-lab.com is hardcoded, and `print_plaque.py` divided the power by 220 V no matter what the firmware says. A 110 V machine got a 220 V plate and a current about half of the real one.

## Rule

The 220 V plate does not change by a pixel; only the 110 V one changes. The printer sends its settings (`mains=`, `bedw=` engraved in `YUMI_CONFIG`), the template places them.

## Change (pad side)

- `MAINS_RATINGS`, one table in `print_plaque.py`: `220V` → `{voltage}` = `220–240 V~`, current = P/220 (unchanged); `110V` → `100–120 V~`, current = P/100. Current = (bed power + 120 W PSU) / that voltage, rounded up to the next ampere. **Open point**: the 110 V divisor (100 / 110 / 120 V) is a convention still to be confirmed. C235 gives 5 A at 100 V, 4 A at 110 or 120 V.
- The template receives the range through `{voltage}`; the embedded default template uses `Rated Input: {voltage}, 50/60 Hz, {amps} A`. A unit test renders a 220 V plate on the old and on the routed line and asserts zero pixel difference.
- Guard before printing: exit 4 and nothing printed when `mains=`/`bedw=` are missing from the firmware, or when the template still hardcodes a voltage other than the machine's. A 220 V machine keeps printing on the old template during the transition; a 110 V machine is refused until the live template carries `{voltage}`.
- QC panel: the `QC:PLAQUE:REFUS` line becomes an error popup with the reason, the success line an info popup (`qc_engine.plaque_feedback`, live responses only). Before, a refusal was only visible in the Klipper console.
- `--mains` / `--power` force everything without Moonraker (bench test, manual reprint); `--voltage` only changes the printed label.
- 25 unit tests (`qc/tests/test_m3_plaque.py`).

## Rollout order (matters)

1. Merge this PR, let YUMI_SYNC run `install.sh` on every factory pad (the driver is copied to `~/yumi-m3-plaque/`).
2. Only then switch the live template `https://label.yumi-lab.com/m3-template.json` to `Rated Input: {voltage}, 50/60 Hz, {amps} A` (Label Expert side, repo YUMI-POS-Printer, which also mirrors `m3-driver/`). The old script puts `220V ~ 50/60Hz` in `{voltage}`, so a routed template on an old pad would print `220V ~ 50/60Hz, 50/60 Hz`.

Until step 2, 110 V nameplates must not be printed: the old script prints a wrong 220 V plate silently, the new one refuses.

## Verified

- `python3 -m unittest discover -s qc/tests -t .` → 94 tests OK, each commit green on its own.
- Dry-run C235 110 V on the live template → refused (`QC:PLAQUE:REFUS … au lieu de {voltage} -- machine 100–120 V~`), exit 4 on the real path; 220 V on the live template → not refused; on a routed copy of the live template → `100–120 V~, 5.0 A` and `220–240 V~, 2.0 A`.
- Not yet run on a real pad nor printed on a physical M3.
